### PR TITLE
Fix duplicate node bug in get_interpro_nodes

### DIFF
--- a/bccb/interpro_adapter.py
+++ b/bccb/interpro_adapter.py
@@ -363,13 +363,6 @@ class InterPro:
 
             if self.early_stopping and counter == self.early_stopping:
                 break
-            node_list.append((domain_id, node_label, props))
-
-            counter += 1
-
-            if self.early_stopping and counter == self.early_stopping:
-                break
-
         t1 = time()
         logger.info(f"InterPro nodes created in {round((t1-t0) / 60, 2)} mins")
 


### PR DESCRIPTION
Removed duplicate node_list.append(), counter increment, and early_stopping check block that was causing each domain node to be added twice.