### PR TITLE
Rebuild disgenet_local.py against DisGeNET's new API endpoints

### DIFF
--- a/bccb/disease_adapter.py
+++ b/bccb/disease_adapter.py
@@ -571,10 +571,10 @@ class Disease:
         ]
         batch_size = 10
 
-        # the query functions below return only the payload and discard the
-        # paging metadata, so a full page is the only available signal that
-        # more results are waiting; the API serves 100 records per page
-        page_size = 100
+        # a page past the end comes back as an empty list, so a None means
+        # the request itself failed - the two must not be conflated, or a
+        # batch truncated mid-pagination looks like a completed one
+        self.disgenet_failed_batches = []
 
         if DiseaseEdgeType.DISEASE_TO_DISEASE in self.edge_types:
             t0 = time()
@@ -585,11 +585,24 @@ class Disease:
             for i in tqdm(range(0, len(disease_ids_prefixed), batch_size)):
                 batch = disease_ids_prefixed[i : i + batch_size]
                 page_number = 0
+                # the query functions discard the paging metadata, so the
+                # page size is taken from the first full page rather than
+                # assumed - it is not the same on every account tier
+                page_size = None
 
                 while True:
                     dda_result = self.disgenet_api.get_dda(
                         disease_1=batch, page_number=page_number
                     )
+
+                    if dda_result is None:
+                        self.disgenet_failed_batches.append(("dda", batch))
+                        logger.warning(
+                            f"DDA batch starting at {batch[0]} was cut short "
+                            f"at page {page_number} by a retrieval error; "
+                            f"results for these ids are incomplete."
+                        )
+                        break
 
                     if not dda_result:
                         if page_number == 0:
@@ -602,6 +615,9 @@ class Disease:
                     # from one call now; both lists reference the same records.
                     self.disgenet_dda_gene.extend(dda_result)
                     self.disgenet_dda_variant.extend(dda_result)
+
+                    if page_size is None:
+                        page_size = len(dda_result)
 
                     if len(dda_result) < page_size:
                         break
@@ -642,10 +658,20 @@ class Disease:
                 batch = disease_ids_prefixed[i : i + batch_size]
 
                 page_number = 0
+                page_size = None
                 while True:
                     gda_result = self.disgenet_api.get_gda_summary(
                         disease=batch, page_number=page_number
                     )
+
+                    if gda_result is None:
+                        self.disgenet_failed_batches.append(("gda", batch))
+                        logger.warning(
+                            f"GDA batch starting at {batch[0]} was cut short "
+                            f"at page {page_number} by a retrieval error; "
+                            f"results for these ids are incomplete."
+                        )
+                        break
 
                     if not gda_result:
                         if page_number == 0:
@@ -656,16 +682,29 @@ class Disease:
 
                     self.disgenet_gda.extend(gda_result)
 
+                    if page_size is None:
+                        page_size = len(gda_result)
+
                     if len(gda_result) < page_size:
                         break
 
                     page_number += 1
 
                 page_number = 0
+                page_size = None
                 while True:
                     vda_result = self.disgenet_api.get_vda_summary(
                         disease=batch, page_number=page_number
                     )
+
+                    if vda_result is None:
+                        self.disgenet_failed_batches.append(("vda", batch))
+                        logger.warning(
+                            f"VDA batch starting at {batch[0]} was cut short "
+                            f"at page {page_number} by a retrieval error; "
+                            f"results for these ids are incomplete."
+                        )
+                        break
 
                     if not vda_result:
                         if page_number == 0:
@@ -675,6 +714,9 @@ class Disease:
                         break
 
                     self.disgenet_vda.extend(vda_result)
+
+                    if page_size is None:
+                        page_size = len(vda_result)
 
                     if len(vda_result) < page_size:
                         break
@@ -686,7 +728,15 @@ class Disease:
                 f"Disgenet gene-disease interaction data is downloaded in {round((t1-t0) / 60, 2)} mins"
             )
 
-    def download_malacards_data(self, 
+        if self.disgenet_failed_batches:
+            logger.warning(
+                f"{len(self.disgenet_failed_batches)} Disgenet batches were "
+                f"cut short by a retrieval error, so the downloaded data is "
+                f"incomplete. The affected query types and ids are in "
+                f"self.disgenet_failed_batches."
+            )
+
+    def download_malacards_data(self,
                                 malacards_json_path: FilePath | None = None, 
                                 malacards_related_diseases_json_path: FilePath | None = None) -> None:
 
@@ -784,9 +834,20 @@ class Disease:
             if not term.is_obsolete and term.obo_id and "MONDO" in term.obo_id
         ]
 
-        disgenet_id_mappings = disgenet.disease_id_mappings(
+        disgenet_id_mappings, failed_batches = disgenet.disease_id_mappings(
             self.disgenet_api, mondo_ids, batch_size=10
         )
+
+        self.disgenet_failed_id_mapping_batches = failed_batches
+
+        if failed_batches:
+            logger.warning(
+                f"{len(failed_batches)} of "
+                f"{-(-len(mondo_ids) // 10)} Disgenet id mapping batches "
+                f"were cut short by a retrieval error; the mappings below "
+                f"are incomplete. Affected ids are in "
+                f"self.disgenet_failed_id_mapping_batches."
+            )
 
         # vocabulary prefixes as sent by the API in diseaseVocabularies;
         # every entry except MONDO needs a counterpart in

--- a/bccb/disease_adapter.py
+++ b/bccb/disease_adapter.py
@@ -556,51 +556,57 @@ class Disease:
             )
 
     def download_disgenet_data(self) -> None:
-        if not hasattr(self, "disgenet_id_mappings_dict"):
+        if not hasattr(self, "disgenet_api"):
+            self.disgenet_api = disgenet.DisgenetApi()
+
+        if not hasattr(self, "disgenet_disease_ids") or not hasattr(
+            self, "disgenet_id_mappings_dict"
+        ):
             self.prepare_disgenet_id_mappings()
 
-        if not hasattr(self, "uniprot_to_entrez"):
-            uniprot_to_entrez = uniprot.uniprot_data(
-                "xref_geneid", "9606", True
-            )
-            self.uniprot_to_entrez = {
-                k: v.strip(";").split(";")[0]
-                for k, v in uniprot_to_entrez.items()
-            }
+        # DisGeNET query functions expect vocabulary-prefixed disease ids
+        # (e.g. "UMLS_C0006142"); disgenet_disease_ids holds bare CUIs.
+        disease_ids_prefixed = [
+            f"UMLS_{disease_id}" for disease_id in self.disgenet_disease_ids
+        ]
+        batch_size = 10
 
-        self.gene_symbol_to_uniprot = {}
-        for k, v in uniprot.uniprot_data("gene_names", "9606", True).items():
-            for symbol in v.split(" "):
-                self.gene_symbol_to_uniprot[symbol] = k
+        # the query functions below return only the payload and discard the
+        # paging metadata, so a full page is the only available signal that
+        # more results are waiting; the API serves 100 records per page
+        page_size = 100
 
         if DiseaseEdgeType.DISEASE_TO_DISEASE in self.edge_types:
             t0 = time()
 
-            if not hasattr(self, "disgenet_api"):
-                self.disgenet_api = disgenet.DisgenetApi()
-
-            if not hasattr(self, "disgenet_disease_ids"):
-                self.disgenet_disease_ids = (
-                    disgenet.disease_id_mappings().keys()
-                )
-
-            if not hasattr(self, "disgenet_id_mappings_dict"):
-                self.prepare_disgenet_id_mappings()
-
             self.disgenet_dda_gene = []
             self.disgenet_dda_variant = []
-            for disease_id in tqdm(self.disgenet_disease_ids):
-                try:
-                    self.disgenet_dda_gene.extend(
-                        self.disgenet_api.get_ddas_that_share_genes(disease_id)
+
+            for i in tqdm(range(0, len(disease_ids_prefixed), batch_size)):
+                batch = disease_ids_prefixed[i : i + batch_size]
+                page_number = 0
+
+                while True:
+                    dda_result = self.disgenet_api.get_dda(
+                        disease_1=batch, page_number=page_number
                     )
-                    self.disgenet_dda_variant.extend(
-                        self.disgenet_api.get_ddas_that_share_variants(
-                            disease_id
-                        )
-                    )
-                except TypeError:
-                    logger.debug(f"{disease_id} not available")
+
+                    if not dda_result:
+                        if page_number == 0:
+                            logger.debug(
+                                f"DDA batch starting at {batch[0]} not available"
+                            )
+                        break
+
+                    # get_dda() returns both jaccard_genes and jaccard_variants
+                    # from one call now; both lists reference the same records.
+                    self.disgenet_dda_gene.extend(dda_result)
+                    self.disgenet_dda_variant.extend(dda_result)
+
+                    if len(dda_result) < page_size:
+                        break
+
+                    page_number += 1
 
             t1 = time()
             logger.info(
@@ -610,19 +616,8 @@ class Disease:
         if DiseaseEdgeType.GENE_TO_DISEASE in self.edge_types:
             t0 = time()
 
-            if not hasattr(self, "disgenet_api"):
-                self.disgenet_api = disgenet.DisgenetApi()
-
-            if not hasattr(self, "disgenet_disease_ids") or not hasattr(
-                self, "disgenet_id_mappings_dict"
-            ):
-                self.disgenet_disease_ids = (
-                    disgenet.disease_id_mappings().keys()
-                )
-
-            if not hasattr(self, "disgenet_id_mappings_dict"):
-                self.prepare_disgenet_id_mappings()
-
+            # only the variant-disease step below needs these mappings, so
+            # they are built here rather than for every edge type
             if not hasattr(self, "uniprot_to_entrez"):
                 uniprot_to_entrez = uniprot.uniprot_data(
                     "xref_geneid", "9606", True
@@ -632,26 +627,59 @@ class Disease:
                     for k, v in uniprot_to_entrez.items()
                 }
 
-            self.gene_symbol_to_uniprot = {}
-            for k, v in uniprot.uniprot_data(
-                "gene_names", "9606", True
-            ).items():
-                for symbol in v.split(" "):
-                    self.gene_symbol_to_uniprot[symbol] = k
+            if not hasattr(self, "gene_symbol_to_uniprot"):
+                self.gene_symbol_to_uniprot = {}
+                for k, v in uniprot.uniprot_data(
+                    "gene_names", "9606", True
+                ).items():
+                    for symbol in v.split(" "):
+                        self.gene_symbol_to_uniprot[symbol] = k
 
             self.disgenet_gda = []
             self.disgenet_vda = []
-            for disease_id in tqdm(self.disgenet_disease_ids):
-                try:
-                    self.disgenet_gda.extend(
-                        self.disgenet_api.get_gdas_by_diseases(disease_id)
-                    )
-                    self.disgenet_vda.extend(
-                        self.disgenet_api.get_vdas_by_diseases(disease_id)
+
+            for i in tqdm(range(0, len(disease_ids_prefixed), batch_size)):
+                batch = disease_ids_prefixed[i : i + batch_size]
+
+                page_number = 0
+                while True:
+                    gda_result = self.disgenet_api.get_gda_summary(
+                        disease=batch, page_number=page_number
                     )
 
-                except (TypeError, ValueError) as e:
-                    logger.debug(f"{disease_id} not available")
+                    if not gda_result:
+                        if page_number == 0:
+                            logger.debug(
+                                f"GDA batch starting at {batch[0]} not available"
+                            )
+                        break
+
+                    self.disgenet_gda.extend(gda_result)
+
+                    if len(gda_result) < page_size:
+                        break
+
+                    page_number += 1
+
+                page_number = 0
+                while True:
+                    vda_result = self.disgenet_api.get_vda_summary(
+                        disease=batch, page_number=page_number
+                    )
+
+                    if not vda_result:
+                        if page_number == 0:
+                            logger.debug(
+                                f"VDA batch starting at {batch[0]} not available"
+                            )
+                        break
+
+                    self.disgenet_vda.extend(vda_result)
+
+                    if len(vda_result) < page_size:
+                        break
+
+                    page_number += 1
 
             t1 = time()
             logger.info(
@@ -744,18 +772,35 @@ class Disease:
         """
         Prepare disgenet id mappings
         """
+        if not hasattr(self, "mondo"):
+            self.download_mondo_data()
 
-        disgenet_id_mappings = disgenet.disease_id_mappings()
+        if not hasattr(self, "disgenet_api"):
+            self.disgenet_api = disgenet.DisgenetApi()
 
+        mondo_ids = [
+            term.obo_id.replace(":", "_")
+            for term in self.mondo
+            if not term.is_obsolete and term.obo_id and "MONDO" in term.obo_id
+        ]
+
+        disgenet_id_mappings = disgenet.disease_id_mappings(
+            self.disgenet_api, mondo_ids, batch_size=10
+        )
+
+        # vocabulary prefixes as sent by the API in diseaseVocabularies;
+        # every entry except MONDO needs a counterpart in
+        # `disgenet_dbs_to_mondo_dbs` in map_disgenet_disease_id_to_mondo_id
         selected_dbs = [
             "DO",
             "EFO",
             "HPO",
             "MONDO",
-            "MSH",
+            "MESH",
             "NCI",
-            "ICD10CM",
+            "ICD10",
             "OMIM",
+            "ORDO",
         ]
         self.disgenet_id_mappings_dict = collections.defaultdict(dict)
 
@@ -771,6 +816,8 @@ class Disease:
                     )
 
             self.disgenet_id_mappings_dict[disg_id] = map_dict
+
+        self.disgenet_disease_ids = list(disgenet_id_mappings.keys())
 
     def prepare_malacards_mondo_mappings(self, malacards_external_ids):
 
@@ -1404,20 +1451,19 @@ class Disease:
 
         df_list = []
         for vda in self.disgenet_vda:
-            if vda.gene_symbol and self.uniprot_to_entrez.get(
-                self.gene_symbol_to_uniprot.get(vda.gene_symbol)
-            ):
+            gene_id = (
+                self._resolve_gene_symbol_to_entrez(vda.gene_symbol)
+                if vda.gene_symbol
+                else None
+            )
+
+            if gene_id:
                 diseaseid = self.map_disgenet_disease_id_to_mondo_id(
                     vda.diseaseid, return_pandas_none=False
                 )
-                gene_id = str(
-                    self.uniprot_to_entrez.get(
-                        self.gene_symbol_to_uniprot.get(vda.gene_symbol)
-                    )
-                )
-                if diseaseid and gene_id:
+                if diseaseid:
                     df_list.append(
-                        (gene_id, diseaseid, vda.score, vda.variantid)
+                        (str(gene_id), diseaseid, vda.score, vda.variantid)
                     )
 
         disgenet_vda_df = pd.DataFrame(
@@ -1466,7 +1512,7 @@ class Disease:
         df_list = []
         # DISEASE-DISEASE BY GENE
         for dda in self.disgenet_dda_gene:
-            if round(dda.jaccard_genes, 3) != 0.0:
+            if dda.jaccard_genes is not None and round(dda.jaccard_genes, 3) != 0.0:
                 diseaseid1 = self.map_disgenet_disease_id_to_mondo_id(
                     dda.diseaseid1, return_pandas_none=False
                 )
@@ -1508,7 +1554,7 @@ class Disease:
         df_list = []
         # DISEASE-DISEASE BY VARIANT
         for dda in self.disgenet_dda_variant:
-            if round(dda.jaccard_variants, 3) != 0.0:
+            if dda.jaccard_variants is not None and round(dda.jaccard_variants, 3) != 0.0:
                 diseaseid1 = self.map_disgenet_disease_id_to_mondo_id(
                     dda.diseaseid1, return_pandas_none=False
                 )
@@ -2287,6 +2333,21 @@ class Disease:
     def ensure_iterable(self, element):
         return element if isinstance(element, (list, tuple, set)) else [element]
 
+    def _resolve_gene_symbol_to_entrez(self, gene_symbols):
+        """
+        vda.gene_symbol is a tuple that may contain more than one symbol
+        (e.g. an overlapping gene pair like ('NBR2', 'BRCA1')). Tries each
+        symbol in order and returns the Entrez gene id for the first one
+        that resolves through gene_symbol_to_uniprot -> uniprot_to_entrez.
+        Returns None if none of the symbols resolve.
+        """
+        for symbol in gene_symbols:
+            uniprot_id = self.gene_symbol_to_uniprot.get(symbol)
+            if uniprot_id and self.uniprot_to_entrez.get(uniprot_id):
+                return self.uniprot_to_entrez.get(uniprot_id)
+
+        return None
+
     def map_disgenet_disease_id_to_mondo_id(
         self, disgenet_id, return_pandas_none=True
     ):
@@ -2295,10 +2356,11 @@ class Disease:
             "DO": "DOID",
             "EFO": "EFO",
             "HPO": "HP",
-            "MSH": "MESH",
+            "MESH": "MESH",
             "NCI": "NCIT",
-            "ICD10CM": "ICD10CM",
+            "ICD10": "ICD10CM",
             "OMIM": "OMIM",
+            "ORDO": "Orphanet",
         }
 
         diseaseid = self.mondo_mappings["UMLS"].get(disgenet_id)

--- a/bccb/disgenet_local.py
+++ b/bccb/disgenet_local.py
@@ -653,9 +653,13 @@ class DisgenetApi:
     ):
         """
         Returns Disease-Disease Associations between disease_1 and disease_2.
-        The API returns both gene-sharing and variant-sharing metrics
-        together in a single query, so both jaccard_genes and
-        jaccard_variants are always populated.
+        The API returns gene-sharing and variant-sharing metrics together
+        in a single query, but a given pair only carries the metrics it
+        actually has: a pair that shares genes but no variants comes back
+        with jaccard_variants (and pvalue_jaccard_variants) set to None.
+        This is common rather than exceptional - in a 636-record sample
+        jaccard_variants was None in 382 of them. Callers must guard
+        against None before doing arithmetic on either jaccard field.
 
         @disease_1: Union[str, List[str]]
         Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".

--- a/bccb/disgenet_local.py
+++ b/bccb/disgenet_local.py
@@ -23,6 +23,7 @@
 #  Website: http://pypath.omnipathdb.org/
 #
 
+import os
 import collections
 import csv
 import json
@@ -33,7 +34,6 @@ from typing import List, Union, NamedTuple, Dict, Tuple, Optional, Literal
 import pypath.share.curl as curl
 import pypath.share.session as session
 import pypath.resources.urls as urls
-import pypath.utils.mapping as mapping
 
 _logger = session.Logger(name="disgenet_input")
 _log = _logger._log
@@ -45,8 +45,6 @@ class DisgenetApi:
     _api_url = urls.urls["disgenet"]["api_url"]
     _authenticated: bool = False
     _api_key: str = None
-    e_mail: str = None
-    password: str = None
 
     def authenticate(self) -> bool:
         """
@@ -58,12 +56,15 @@ class DisgenetApi:
             return True
 
         print(f"Authorizing in {self._name} API...")
-        # DisGeNET migrated from email/password login (returning a session
-        # token) to a static per-user API key generated on their website.
-        # There is no /auth/ endpoint to call anymore, so we just prompt
-        # for the key and store it directly instead of making a POST
-        # request and parsing a token from the response.
-        api_key: str = getpass("API Key: ")
+        # DisGeNET auth is a static per-user API key, no token exchange needed.
+        # Checks DISGENET_API_KEY env var first so long batch runs aren't
+        # interrupted by a prompt; falls back to getpass otherwise.
+        api_key: str = os.environ.get("DISGENET_API_KEY") or getpass("API Key: ")
+
+        if not api_key:
+            print(f"No API key provided for {self._name} API.")
+            self._authenticated = False
+            return False
 
         self._api_key = api_key
         self._authenticated = True
@@ -98,23 +99,6 @@ class DisgenetApi:
 
         return wrapper
 
-    # get_ddas_that_share_genes() and get_ddas_that_share_variants() were
-    # removed: the new DisGeNET DDA API has a single /dda endpoint that
-    # always returns both gene-sharing and variant-sharing metrics
-    # together in one query, so the separate genes/variants split no
-    # longer applies.
-
-    
-    # _get_vdas(), get_vdas_by_variants(), get_vdas_by_genes(),
-    # get_vdas_by_diseases(), and get_vdas_by_source() were removed. These
-    # five functions existed to select a "by" routing mode (gene, disease,
-    # variant, source) for the old path-based /vda/{by}/... endpoint,
-    # where each identifier type required a different URL. The new API
-    # has a single fixed endpoint (/vda/summary) where variant, gene,
-    # disease, source, etc. are all just optional query parameters on the
-    # same call, so there's no more separate URL/routing per identifier
-    # type. Replaced by the single get_vda_summary() function below, which
-    # accepts all identifier types and filters at once.
 
     def get_vda_summary(
     self,
@@ -152,44 +136,38 @@ class DisgenetApi:
         ("ei", float),
         ("year_initial", int),
         ("year_final", int),
-        ("source", str),
+        ("source", Tuple[str]),
     ],
 ):
         """
-        Returns Variant-Disease Associations (aggregated summary), narrowed
-        to the fields the old get_vdas_by_variants/genes/diseases/source()
-        functions returned.
+        Returns Variant-Disease Associations.
 
-        disease_type is now populated from the API's "diseaseType" field.
-        It was previously hardcoded to None based on an incorrect reading
-        of the response schema; confirmed via real test data (e.g.
-        disease_type='phenotype' for a real query) that this field is
-        actually present in /vda/summary's response.
+        @diseaseClasses_HPO: Usually None; kept to avoid dropping this
+        classification when it is populated for a given variant/gene.
 
-        disease_class_name is not included: same situation as in
-        get_dda/get_gda_summary - the old API had a separate class-name
-        field, the new API only returns the combined "name (code)" string
-        in disease_class.
+        @source (returned field): Curated source names derived from
+        scoreBreakdown.components.curated.sources; may contain multiple
+        values.
+        
 
         @variant: Union[str, List[str]]
             Variant (dbSNP Identifier) or list of variants, up to 100.
         @gene_ncbi_id / @gene_symbol: Union[str, List[str]]
-            Gene identifier(s); the old "gene" param accepted either NCBI
-            ID or HGNC symbol, the new API splits these into two params.
+        Gene identifier, as NCBI ID or symbol (separate params).
         @disease: Union[str, List[str]]
             Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
         @source: Union[str, List[str]]
             Source of the VDA.
         @min_score/@max_score, @min_ei/@max_ei, @min_dsi/@max_dsi,
         @min_dpi/@max_dpi: float
-            Score ranges, in [0,1].
+            Filters on the API's raw score field, which is not bounded to
+            [0,1] (unlike normalized_score, which has no separate filter
+            param). ei/dsi/dpi ranges are in [0,1].
         @dis_class_list: Union[str, List[str]]
-            MeSH Disease Classes - corresponds to the old "disease_class"
-            param.
+            MeSH Disease Classes.
         @page_number: int
-            Page number - corresponds to the old "limit" param (100 per
-            page; TRIAL accounts are capped at the top-30 results and do
-            not support pagination).
+            Page number (100 results per page; TRIAL accounts are capped
+            at the top-30 results and do not support pagination).
         """
 
         url = f"{self._api_url}/vda/summary"
@@ -240,7 +218,7 @@ class DisgenetApi:
         if page_number != None:
             get_params["page_number"] = str(page_number)
 
-        result = self._retrieve_data(url, get_params)
+        result, _ = self._retrieve_data(url, get_params)
 
         if result == None:
             return None
@@ -278,31 +256,23 @@ class DisgenetApi:
                 self._get_string(entry.get("diseaseUMLSCUI")),
                 self._get_string(entry.get("diseaseName")),
                 tuple(entry["diseaseClasses_DO"]) if entry.get("diseaseClasses_DO") else None,
-                tuple(entry["diseaseClasses_HPO"]) if entry.get("diseaseClasses_HPO") else None, # Likely None for most records, but keeping the field since it may be populated depending on the variant/gene - didn't want to silently drop this classification data.
+                tuple(entry["diseaseClasses_HPO"]) if entry.get("diseaseClasses_HPO") else None, 
                 tuple(entry["diseaseClasses_MSH"]) if entry.get("diseaseClasses_MSH") else None,
                 tuple(entry["diseaseClasses_UMLS_ST"]) if entry.get("diseaseClasses_UMLS_ST") else None,
-                self._get_string(entry.get("diseaseType")),
-                self._get_float(entry.get("score")),
+                self._get_string(entry.get("diseaseType")).strip("[]") if entry.get("diseaseType") else None,
+                self._get_float(entry.get("normalized_score")),
                 self._get_float(entry.get("ei")),
                 self._get_int(entry.get("yearInitial")),
                 self._get_int(entry.get("yearFinal")),
-                self._get_string(entry.get("source")),
+                self._get_curated_sources(entry),
             )
 
         return result
 
     
-    # get_gdas_by_genes(), get_gdas_by_diseases(), get_gdas_by_uniprots(),
-    # get_gdas_by_source(), and _get_gdas() were removed. These functions
-    # existed to select a "by" routing mode (gene, disease, uniprot,
-    # source) for the old path-based /gda/{by}/... endpoint, where each
-    # identifier type required a different URL. The new API has a single
-    # fixed endpoint (/gda/summary) where gene, disease, uniprot, source,
-    # etc. are all just optional query parameters on the same call, so
-    # there's no more separate URL/routing per identifier type. Replaced
-    # by the single get_gda_summary() function below, which accepts all
-    # identifier types and filters at once. This mirrors the same removal
-    # already done for the VDA summary functions (get_vdas_by_*/_get_vdas).
+    # /gda/summary takes every identifier type (gene, disease, uniprot, source, ...)
+    # as an optional query parameter on a single call, so one function covers all
+    # identifier types and filters at once.
     def get_gda_summary(
         self,
         gene_ncbi_id: Union[str, List[str]] = None,
@@ -347,13 +317,15 @@ class DisgenetApi:
             ("el", str),
             ("year_initial", int),
             ("year_final", int),
-            ("source", str),
+            ("source", Tuple[str]),
         ],
     ):
         """
-        Returns Gene-Disease Associations (aggregated summary), narrowed
-        to the fields the old get_gdas_by_genes/diseases/uniprots/source()
-        functions returned.
+        Returns Gene-Disease Associations.
+
+        @source (returned field): Curated source names derived from
+        scoreBreakdown.components.curated.sources; may contain multiple
+        values.
 
         @gene_ncbi_id / @gene_ensembl_id / @gene_symbol: Union[str, List[str]]
             Gene identifier(s) in the respective vocabulary, up to 100.
@@ -365,16 +337,16 @@ class DisgenetApi:
             Source of the GDA.
         @min_score/@max_score, @min_ei/@max_ei, @min_dsi/@max_dsi,
         @min_dpi/@max_dpi, @min_pli/@max_pli: float
-            Score ranges, in [0,1].
+            Filters on the API's raw score field, which is not bounded to
+            [0,1] (unlike normalized_score, which has no separate filter
+            param). ei/dsi/dpi ranges are in [0,1].
         @type: str
             DisGeNET Disease Type ("disease", "phenotype", "group").
         @dis_class_list: Union[str, List[str]]
-            MeSH Disease Classes - corresponds to the old "disease_class"
-            param.
+            MeSH Disease Classes.
         @page_number: int
-            Page number - corresponds to the old "limit" param (100 per
-            page; TRIAL accounts are capped at the top-30 results and do
-            not support pagination).
+            Page number (100 results per page; TRIAL accounts are capped
+            at the top-30 results and do not support pagination).
         """
 
         url = f"{self._api_url}/gda/summary"
@@ -437,7 +409,7 @@ class DisgenetApi:
         if page_number != None:
             get_params["page_number"] = str(page_number)
 
-        result = self._retrieve_data(url, get_params)
+        result, _ = self._retrieve_data(url, get_params)
 
         if result == None:
             return None
@@ -485,28 +457,20 @@ class DisgenetApi:
                 tuple(entry["diseaseClasses_HPO"]) if entry.get("diseaseClasses_HPO") else None,
                 tuple(entry["diseaseClasses_MSH"]) if entry.get("diseaseClasses_MSH") else None,
                 tuple(entry["diseaseClasses_UMLS_ST"]) if entry.get("diseaseClasses_UMLS_ST") else None,
-                self._get_string(entry.get("diseaseType")),
-                self._get_float(entry.get("score")),
+                self._get_string(entry.get("diseaseType")).strip("[]") if entry.get("diseaseType") else None,
+                self._get_float(entry.get("normalized_score")),
                 self._get_float(entry.get("ei")),
                 self._get_string(entry.get("el")),
                 self._get_int(entry.get("yearInitial")),
                 self._get_int(entry.get("yearFinal")),
-                self._get_string(entry.get("source")),
+                self._get_curated_sources(entry),
             )
 
         return result
 
     
         
-    # get_vda_evidences_by_variant() and get_vda_evidences_by_disease() were
-    # removed. They existed only to select a "by" routing mode for the old
-    # path-based /vda/evidences/{by}/... endpoint. The new API has a single
-    # fixed endpoint (/vda/evidence). Replaced by get_vda_evidence() below,
-    # which keeps only the params the old functions/​_get_evidences() used
-    # (variant/gene/disease, source, min/max_year, min/max_score,
-    # limit/offset) rather than the full param set the new endpoint
-    # supports. Like the old code, this does not convert results into a
-    # namedtuple - it returns the raw list of record dicts as-is.
+
     def get_vda_evidence(
         self,
         variant: Union[str, List[str]] = None,
@@ -521,34 +485,27 @@ class DisgenetApi:
         page_number: int = None,
     ):
         """
-        Returns evidences that support Variant-Disease Associations.
-        Params narrowed to what the old get_vda_evidences_by_variant()/
-        get_vda_evidences_by_disease() (via _get_evidences()) used.
+        Returns evidences that support Variant-Disease Associations. Does
+        not convert results into a namedtuple, it returns the raw list of
+        record dicts as-is.
 
         @variant: Union[str, List[str]]
             Variant (dbSNP Identifier) or list of variants, up to 100.
         @gene_ncbi_id / @gene_symbol: Union[str, List[str]]
-            Gene identifier(s); the old "gene" param accepted either.
+            Gene identifier, as NCBI ID or symbol (separate params).
         @disease: Union[str, List[str]]
             Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
         @source: Union[str, List[str]]
             Source of the VDA.
         @min_pmYear/@max_pmYear: str
-            Publication year range - corresponds to the old
-            "min_year"/"max_year" params. The new API has both
-            min_timestamp/max_timestamp (evidence timestamp) and
-            min_pmYear/max_pmYear (publication year); mapped to the latter
-            as the closer match, but this is an assumption, not confirmed.
+            Publication year range (filters on pmYear, not the evidence
+            timestamp).
         @min_score/@max_score: float
             Variant-disease normalized score range, in [0,1].
         @page_number: int
-            Page number - corresponds to the old "limit"/"offset" params.
-            The old code auto-looped through cursor-based pages
-            (data["next"]) when get_all=True; the new API paginates via
-            page_number instead of a cursor, and TRIAL accounts don't
-            support pagination at all, so the auto-loop was removed. This
-            returns a single page; call again with an incremented
-            page_number for more.
+            Page number. Returns a single page; call again with an
+            incremented page_number for more. TRIAL accounts do not
+            support pagination.
         """
 
         url = f"{self._api_url}/vda/evidence"
@@ -584,13 +541,12 @@ class DisgenetApi:
         if page_number != None:
             get_params["page_number"] = str(page_number)
 
-        return self._retrieve_data(url, get_params)
+        result, _ = self._retrieve_data(url, get_params)
+
+        return result
 
 
-    # get_gda_evidences_by_gene() and get_gda_evidences_by_disease() were
-    # removed, for the same reason as the VDA evidence functions above.
-    # Replaced by get_gda_evidence() below, same narrowed-param approach,
-    # same raw-passthrough (no namedtuple) behavior as the old code.
+    
     def get_gda_evidence(
         self,
         gene_ncbi_id: Union[str, List[str]] = None,
@@ -604,25 +560,25 @@ class DisgenetApi:
         page_number: int = None,
     ):
         """
-        Returns evidences that support Gene-Disease Associations.
-        Params narrowed to what the old get_gda_evidences_by_gene()/
-        get_gda_evidences_by_disease() (via _get_evidences()) used.
+        Returns evidences that support Gene-Disease Associations. Does not
+        convert results into a namedtuple either, it returns the raw list
+        of record dicts as-is.
 
         @gene_ncbi_id / @gene_symbol: Union[str, List[str]]
-            Gene identifier(s); the old "gene" param accepted either.
+            Gene identifier, as NCBI ID or symbol (separate params).
         @disease: Union[str, List[str]]
             Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
         @source: Union[str, List[str]]
             Source of the GDA.
         @min_pmYear/@max_pmYear: str
-            Publication year range - corresponds to the old
-            "min_year"/"max_year" params (same assumption noted in
-            get_vda_evidence above).
+            Publication year range (filters on pmYear, not the evidence
+            timestamp).
         @min_score/@max_score: float
             Gene-disease normalized score range, in [0,1].
         @page_number: int
-            Page number - corresponds to the old "limit"/"offset" params
-            (same auto-loop removal noted in get_vda_evidence above).
+            Page number. Returns a single page; call again with an
+            incremented page_number for more. TRIAL accounts do not
+            support pagination.
         """
 
         url = f"{self._api_url}/gda/evidence"
@@ -655,24 +611,16 @@ class DisgenetApi:
         if page_number != None:
             get_params["page_number"] = str(page_number)
 
-        return self._retrieve_data(url, get_params)
+        result, _ = self._retrieve_data(url, get_params)
+
+        return result
     
     
-    # get_gda_evidences_by_gene() and get_gda_evidences_by_disease() (and
-    # the "gda" branch of the shared _get_evidences()) were removed. They
-    # existed only to select a "by" routing mode (gene vs disease) for the
-    # old path-based /gda/evidences/{by}/... endpoint. The new API has a
-    # single fixed endpoint (/gda/evidence) where gene, disease, chemical,
-    # etc. are all just optional query parameters on the same call, so
-    # there's no more separate URL/routing per identifier type. Replaced
-    # by the single get_gda_evidence() function below, which accepts all
-    # identifier types at once. This also mirrors the same removal already
-    # done for get_vda_evidences_by_variant()/by_disease().
 
     def get_dda(
         self,
         disease_1: Union[str, List[str]],
-        disease_2: Union[str, List[str]],
+        disease_2: Union[str, List[str]] = None,
         source: Union[str, List[str]] = None,
         page_number: int = None,
     ) -> NamedTuple(
@@ -705,35 +653,31 @@ class DisgenetApi:
     ):
         """
         Returns Disease-Disease Associations between disease_1 and disease_2.
-        Fields narrowed to the union of what the old
-        get_ddas_that_share_genes()/get_ddas_that_share_variants() returned;
-        the new API returns both gene-sharing and variant-sharing metrics
+        The API returns both gene-sharing and variant-sharing metrics
         together in a single query, so both jaccard_genes and
-        jaccard_variants are always populated (the old code only returned
-        one or the other depending on which function was called). The old
-        duplicate fields disease1_ngenes/disease2_ngenes/disease1_nvariants/
-        disease2_nvariants (which held the same values as ngenes1/ngenes2/
-        nvariants1/nvariants2) were consolidated into the single generic
-        fields, since the new API only exposes one copy of each.
+        jaccard_variants are always populated.
 
-        @disease_1 / @disease_2: Union[str, List[str]]
-            Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
+        @disease_1: Union[str, List[str]]
+        Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
+        @disease_2: Union[str, List[str]], optional
+            Disease id(s) with vocabulary prefix. If omitted, returns all
+            diseases sharing genes/variants with disease_1.
         @source: Union[str, List[str]]
             Source of the DDA.
         @page_number: int
-            Page number - corresponds to the old "limit" param (100 per
-            page; TRIAL accounts are capped at the top-10 results and do
-            not support pagination).
+            Page number (100 results per page; TRIAL accounts are capped
+            at the top-10 results and do not support pagination).
         """
 
         disease_1 = self._list_to_str(disease_1, "Disease 1 ID", limit=100)
-        disease_2 = self._list_to_str(disease_2, "Disease 2 ID", limit=100)
 
         url = f"{self._api_url}/dda"
         get_params = dict()
 
         get_params["disease_1"] = disease_1
-        get_params["disease_2"] = disease_2
+
+        if disease_2 != None:
+            get_params["disease_2"] = self._list_to_str(disease_2, "Disease 2 ID", limit=100)
 
         if source != None:
             get_params["source"] = source
@@ -741,7 +685,7 @@ class DisgenetApi:
         if page_number != None:
             get_params["page_number"] = str(page_number)
 
-        result = self._retrieve_data(url, get_params)
+        result, _ = self._retrieve_data(url, get_params)
 
         if result == None:
             return None
@@ -804,13 +748,6 @@ class DisgenetApi:
             )
 
         return result
-    # _get_evidences() was removed. It tried to share one generic function
-    # between GDA and VDA evidence retrieval using "of"/"by" flags for
-    # path-based routing (e.g. /vda/evidences/variant/...). The new API
-    # has separate, fixed endpoints (/gda/evidence, /vda/evidence) with
-    # much richer, endpoint-specific parameters (e.g. chromcoord, hgvsc,
-    # hgvsp, min_polyphen for VDA; uniprot_id, nct_phase for GDA), so a
-    # single shared function is no longer a good fit. 
    
     
 
@@ -841,15 +778,12 @@ class DisgenetApi:
 
         return list_obj
 
-    # Re-enabling this decorator: it was previously commented out, which let
-    # _retrieve_data run with no valid api_key and silently send
-    # "Authorization: Bearer None" to the server. Now that authenticate()
-    # is fixed for the new API, this guard is safe to use again.
+    # Guards against calling the API without a valid key.
     @_if_authenticated
-    @_delete_cache
+    #@_delete_cache
     def _retrieve_data(
         self, url: str, get_params: Union[List[str], Dict[str, str]]
-    ) -> List[Dict[str, str]]:
+    ) -> Tuple[Optional[List[Dict[str, str]]], Optional[Dict[str, str]]]:
         """
         Retrieves the data with given request body
 
@@ -857,19 +791,15 @@ class DisgenetApi:
             Query url
         @get_params: Union[List[str], Dict[str, str]]
             GET request parameters
+
+        Returns a (payload, paging) tuple; both are None on failure.
         """
 
         headers = ["accept: */*", f"Authorization: Bearer {self._api_key}"]
 
-        # Any param whose value is a Python list (e.g. source,
-        # dda_relation, dis_class_list) is expanded into repeated
-        # "key=value" entries, one per list item. This replaces the old
-        # code, which only special-cased a single param named
-        # "disease_class" (which no longer exists in the new API; it's
-        # now "dis_class_list") and would otherwise have serialized any
-        # other list param as a literal Python list string, e.g.
-        # "source=['CURATED', 'CLINVAR']", which the DisGeNET API does
-        # not parse correctly.
+        # List-valued params (e.g. source, dis_class_list) are expanded into
+        # repeated "key=value" entries, one per item, since the API doesn't
+        # parse a literal Python list string like "source=['CURATED']".
         get_params_list = []
         for key, value in get_params.items():
             if isinstance(value, list):
@@ -885,17 +815,16 @@ class DisgenetApi:
             result = c.result
             result = json.loads(result)
 
-            # The new API wraps the actual records in a "payload" field
-            # alongside status/paging/warnings metadata. The old code
-            # returned the raw parsed JSON as-is, which worked because
-            # the old API's response body WAS the list of records
-            # directly. Every function below expects a plain list of
-            # record dicts, so we extract "payload" here.
-            return result.get("payload")
+            # Records live under "payload"; "paging" carries pageSize,
+            # totalElements, and currentPageNumber, which callers doing
+            # their own pagination need to detect a short final page,
+            # a mismatched page count, or a truncated result reliably —
+            # rather than inferring completion from len(result) alone.
+            return result.get("payload"), result.get("paging")
 
         _log(f"DisGeNET: an error occurred with the code {c.status}")
-        _log(f"DisGeNET response body: {repr(c.result)}")
-        _log(f"DisGeNET curl object: {vars(c)}")
+        _log(f"DisGeNET response body: {repr(c.result)[:200]}")
+        return None, None # keep return shape consistent for (result, paging) unpacking
 
     def _get_int(self, str_obj) -> int:
         """
@@ -951,6 +880,19 @@ class DisgenetApi:
 
         return str_obj
 
+    def _get_curated_sources(self, entry) -> Optional[Tuple[str]]:
+        """
+    Returns curated source names derived from scoreBreakdown, if present.
+
+    @entry : dict
+        A single record from a /summary or /entity response.
+    """
+        breakdown = entry.get("scoreBreakdown")
+        if not breakdown:
+            return None
+        sources = breakdown[0].get("components", {}).get("curated", {}).get("sources")
+        return tuple(sources) if sources else None
+
 
 @DisgenetApi._delete_cache
 def variant_gene_mappings(
@@ -959,22 +901,15 @@ def variant_gene_mappings(
     batch_size: int = 10,
 ) -> Dict[str, "VariantGeneMapping"]:
     """
-    Builds the same {snpId: [VariantGeneMapping(geneId, geneSymbol,
-    sourceIds), ...]} structure the old bulk-download version produced,
-    but queries the new DisGeNET API instead (no bulk mapping file
-    exists anymore).
+    Builds a {snpId: [VariantGeneMapping(geneId, geneSymbol, sourceIds),
+    ...]} mapping by querying the DisGeNET API.
 
-    Unlike the old version (which took no arguments and downloaded the
-    full DisGeNET variant-gene mapping file), this now requires a list
-    of known NCBI Gene IDs to query against - e.g. from
+    Requires a list of known NCBI Gene IDs to query against - e.g. from
     uniprot_adapter.py's xref_geneid field (same source used for
-    disgenet_annotations()). This queries /entity/variant using
-    gene_ncbi_id, which returns each matching variant's own
-    variantToGenes field - a list of {geneNcbiID, symbolOfGene,
-    geneEnsemblID, sources} already grouped per variant, so no manual
-    grouping across rows is needed (unlike the old bulk file, where the
-    same snpId/geneId pair could appear on multiple rows with different
-    sourceId values that had to be accumulated by hand).
+    disgenet_annotations()). Queries /entity/variant using gene_ncbi_id,
+    which returns each matching variant's own variantToGenes field - a
+    list of {geneNcbiID, symbolOfGene, geneEnsemblID, sources} already
+    grouped per variant, so no manual grouping across rows is needed.
 
     @api: DisgenetApi
         An already-authenticated DisgenetApi instance.
@@ -1008,7 +943,14 @@ def variant_gene_mappings(
                 "page_number": str(page_number),
             }
 
-            result = api._retrieve_data(url, get_params)
+            result, paging = api._retrieve_data(url, get_params)
+
+            if paging is None:
+                # A real error occurred (auth failure, bad response, etc.),
+                # not just an empty final page — stop this batch rather than
+                # silently treating a failure as "pagination complete".
+                _log("DisGeNET: stopping pagination for this batch due to a retrieval error.")
+                break
 
             if not result:
                 break
@@ -1023,20 +965,31 @@ def variant_gene_mappings(
                 if snp_id not in mapping:
                     mapping[snp_id] = []
 
+                existing_pairs = {(m.geneId, m.geneSymbol) for m in mapping[snp_id]}
+
                 for vtg in variant_to_genes:
                     gene_id = vtg.get("geneNcbiID")
                     gene_symbol = vtg.get("symbolOfGene")
                     sources = vtg.get("sources")
 
+                    gene_id_str = api._get_string(gene_id) if gene_id != None else None
+                    pair = (gene_id_str, gene_symbol)
+
+                    if pair in existing_pairs:
+                        continue
+
                     mapping[snp_id].append(
                         VariantGeneMapping(
-                            api._get_string(gene_id) if gene_id != None else None,
+                            gene_id_str,
                             gene_symbol,
                             tuple(sources) if sources else None,
                         )
                     )
+                    existing_pairs.add(pair)
 
-            if len(result) < 100:
+            page_size = paging.get("pageSize", 100)
+
+            if len(result) < page_size:
                 break
 
             page_number += 1
@@ -1051,22 +1004,17 @@ def disease_id_mappings(
     batch_size: int = 10,
 ) -> Dict[str, "DiseaseIdMapping"]:
     """
-    Builds the same {diseaseId: DiseaseIdMapping(name, vocabularies)}
-    structure the old bulk-download version produced, but queries the
-    new DisGeNET API instead (no bulk download endpoint exists anymore).
+    Builds a {diseaseId: DiseaseIdMapping(name, vocabularies)} mapping by
+    querying the DisGeNET API.
 
-    Unlike the old version (which took no arguments and downloaded the
-    full DisGeNET disease list), this now requires a list of known
-    MONDO disease IDs to query against - e.g. from disease_adapter.py's
-    MONDO ontology download. Each ID must be in the API's expected
-    format, e.g. "MONDO_0007254".
+    Requires a list of known MONDO disease IDs to query against - e.g.
+    from disease_adapter.py's MONDO ontology download. Each ID must be in
+    the API's expected format, e.g. "MONDO_0007254".
 
-    This is a standalone function (not a DisgenetApi method) so it
-    doesn't change how the class itself is called elsewhere; it takes
-    an already-authenticated DisgenetApi instance as a parameter
-    instead, and calls _retrieve_data directly rather than going
-    through get_gda_summary(), because get_gda_summary()'s narrowed
-    output (matching the old API's fields) doesn't include
+    This is a standalone function (not a DisgenetApi method); it takes an
+    already-authenticated DisgenetApi instance as a parameter and calls
+    _retrieve_data directly rather than going through get_gda_summary(),
+    because get_gda_summary()'s narrowed output doesn't include
     diseaseVocabularies, which is exactly the field this function needs.
 
     Note on data shape: /gda/summary returns one row per matching gene
@@ -1074,9 +1022,7 @@ def disease_id_mappings(
     diseaseVocabularies value. We only need that value once per
     disease, so once a disease_id has been recorded we skip it on
     subsequent rows - this does not lose any information, since this
-    function was never collecting gene data in the first place (same
-    as the old bulk-file version, which only ever returned name +
-    vocabularies per disease, no gene info).
+    function only returns name + vocabularies per disease, no gene data.
 
     @api: DisgenetApi
         An already-authenticated DisgenetApi instance.
@@ -1118,7 +1064,14 @@ def disease_id_mappings(
                 "page_number": str(page_number),
             }
 
-            result = api._retrieve_data(url, get_params)
+            result, paging = api._retrieve_data(url, get_params)
+
+            if paging is None:
+                # A real error occurred (auth failure, bad response, etc.),
+                # not just an empty final page — stop this batch rather than
+                # silently treating a failure as "pagination complete".
+                _log("DisGeNET: stopping pagination for this batch due to a retrieval error.")
+                break
 
             if not result:
                 break
@@ -1150,23 +1103,18 @@ def disease_id_mappings(
                         Vocabulary(
                             vocabulary,
                             code,
-                            # The new API only returns short prefixes
-                            # (e.g. "MESH", "MONDO"), not the full
-                            # vocabulary name the old bulk file had
-                            # (e.g. "Medical Subject Headings"). No
-                            # equivalent field exists in the new API
-                            # or the web interface (checked disease
-                            # detail page - it also only shows short
-                            # labels like "MeSH Disease Class", not
-                            # the full vocabulary name), so this is
-                            # left as None rather than guessing.
+                            # diseaseVocabularies carries only short
+                            # prefixes (e.g. "MESH", "MONDO"), no full
+                            # vocabulary name.
                             None,
                         )
                     )
 
                 mapping[disease_id] = DiseaseIdMapping(name, tuple(vocab_list))
 
-            if len(result) < 100:
+            page_size = paging.get("pageSize", 100)
+
+            if len(result) < page_size:
                 break
 
             page_number += 1
@@ -1182,25 +1130,18 @@ def disgenet_annotations(
     batch_size: int = 10,
 ) -> Dict[str, set]:
     """
-    Builds the same {uniprot_id: {DisGeNetAnnotation(...), ...}} structure
-    the old bulk-download version produced, but queries the new DisGeNET
-    API instead (no bulk annotation files exist anymore - confirmed via
-    AIDA that curated_gene_disease_associations is no longer available).
+    Builds a {uniprot_id: {DisGeNetAnnotation(...), ...}} mapping by
+    querying the DisGeNET API.
 
-    Unlike the old version (which took no gene list and downloaded the
-    full DisGeNET file, then mapped gene symbols to UniProt via pypath's
-    own mapping.map_name()), this now requires a list of known NCBI Gene
-    IDs to query against - e.g. from uniprot_adapter.py's xref_geneid
-    field. The gene-symbol-to-UniProt translation step is no longer
-    needed: the new API already returns UniProt IDs directly in
-    geneProteinStrIDs, so we read those instead of calling pypath's
-    mapping module.
+    Requires a list of known NCBI Gene IDs to query against - e.g. from
+    uniprot_adapter.py's xref_geneid field. No gene-symbol-to-UniProt
+    translation is needed: the API returns UniProt IDs directly in
+    geneProteinStrIDs, so those are read straight from the response.
 
     This calls _retrieve_data directly rather than get_gda_summary(),
-    because get_gda_summary()'s narrowed output (matching the old
-    _get_gdas() fields) doesn't include numPMIDs or
-    numDBSNPsupportingAssociation, which map to this function's
-    nof_pmids/nof_snps fields and aren't part of the old GDA shape.
+    because get_gda_summary()'s narrowed output doesn't include numPMIDs
+    or numDBSNPsupportingAssociation, which map to this function's
+    nof_pmids/nof_snps fields.
 
     @api: DisgenetApi
         An already-authenticated DisgenetApi instance.
@@ -1208,11 +1149,7 @@ def disgenet_annotations(
         Known NCBI Gene (Entrez) IDs to query, e.g. ["672", "675", ...].
     @dataset: str
         Only "curated" and "all" are supported (mapped to
-        source=["CURATED"] and no source filter, respectively). The old
-        "literature" and "befree" datasets have no clear 1:1 equivalent
-        in the new API's source list (BEFREE no longer exists; the
-        closest match, TEXTMINING_HUMAN/TEXTMINING_MODELS, isn't the
-        same grouping) - flagging this rather than guessing a mapping.
+        source=["CURATED"] and no source filter, respectively).
     @batch_size: int
         Number of gene IDs to send per request. Kept small (10) by
         default to stay safe under TRIAL account limits while testing;
@@ -1227,10 +1164,10 @@ def disgenet_annotations(
     if dataset not in dataset_source_map:
         _log(
             f"DisGeNET dataset='{dataset}' is not supported. Only 'curated' and "
-            "'all' are mapped to the new API's source filter; 'literature' "
-            "and 'befree' have no clear equivalent in the new source list."
+            "'all' are mapped to the API's source filter; 'literature' "
+            "and 'befree' have no clear equivalent in the source list."
         )
-        return None
+        return {}
 
     source = dataset_source_map[dataset]
 
@@ -1264,7 +1201,14 @@ def disgenet_annotations(
             if source != None:
                 get_params["source"] = source
 
-            result = api._retrieve_data(url, get_params)
+            result, paging = api._retrieve_data(url, get_params)
+
+            if paging is None:
+                # A real error occurred (auth failure, bad response, etc.),
+                # not just an empty final page — stop this batch rather than
+                # silently treating a failure as "pagination complete".
+                _log("DisGeNET: stopping pagination for this batch due to a retrieval error.")
+                break
 
             if not result:
                 break
@@ -1277,21 +1221,15 @@ def disgenet_annotations(
 
                 disease = entry.get("diseaseName")
                 disease_type = entry.get("diseaseType")
-                score = entry.get("score")
+                disease_type = disease_type.strip("[]") if disease_type else None
+                score = entry.get("normalized_score")
                 dsi = entry.get("geneDSI")
                 dpi = entry.get("geneDPI")
                 nof_pmids = entry.get("numPMIDs")
                 nof_snps = entry.get("numDBSNPsupportingAssociation")
 
-                # The new /gda/summary response does not include a
-                # per-record source field (unlike the old API's
-                # GeneDiseaseAssociation, which had one). When a single
-                # source filter was requested (dataset="curated"), that
-                # filter is the only source these aggregated results
-                # could have come from, so we record it as such. For
-                # dataset="all" (no filter), the true per-record source
-                # is unknown, so this is left as None.
-                record_source = tuple(source) if source != None else None
+                
+                record_source = api._get_curated_sources(entry)
 
                 annotation = DisGeNetAnnotation(
                     disease,
@@ -1307,7 +1245,9 @@ def disgenet_annotations(
                 for uniprot in uniprot_ids:
                     data[uniprot].add(annotation)
 
-            if len(result) < 100:
+            page_size = paging.get("pageSize", 100)
+
+            if len(result) < page_size:
                 break
 
             page_number += 1

--- a/bccb/disgenet_local.py
+++ b/bccb/disgenet_local.py
@@ -76,6 +76,10 @@ class DisgenetApi:
         Simple wrapper to get rid of the burden of
         checking authentication status and authenticating
         if already haven't.
+
+        Wraps _retrieve_data, whose callers unpack a (payload, paging)
+        tuple, so a failed authentication has to return that shape too
+        rather than a bare None.
         """
 
         def wrapper(self, *args, **kwargs):
@@ -84,6 +88,7 @@ class DisgenetApi:
 
             else:
                 _log("DisGeNET failure in authorization, check your credentials.")
+                return None, None
 
         return wrapper
 
@@ -145,9 +150,9 @@ class DisgenetApi:
         @diseaseClasses_HPO: Usually None; kept to avoid dropping this
         classification when it is populated for a given variant/gene.
 
-        @source (returned field): Curated source names derived from
-        scoreBreakdown.components.curated.sources; may contain multiple
-        values.
+        @source (returned field): Source names derived from
+        scoreBreakdown, collected across all of its components and
+        deduplicated; may contain multiple values.
         
 
         @variant: Union[str, List[str]]
@@ -160,9 +165,8 @@ class DisgenetApi:
             Source of the VDA.
         @min_score/@max_score, @min_ei/@max_ei, @min_dsi/@max_dsi,
         @min_dpi/@max_dpi: float
-            Filters on the API's raw score field, which is not bounded to
-            [0,1] (unlike normalized_score, which has no separate filter
-            param). ei/dsi/dpi ranges are in [0,1].
+            Score ranges, in [0,1]. min_score/max_score filter on
+            normalized_score, matching the returned score field.
         @dis_class_list: Union[str, List[str]]
             MeSH Disease Classes.
         @page_number: int
@@ -264,7 +268,7 @@ class DisgenetApi:
                 self._get_float(entry.get("ei")),
                 self._get_int(entry.get("yearInitial")),
                 self._get_int(entry.get("yearFinal")),
-                self._get_curated_sources(entry),
+                self._get_sources(entry),
             )
 
         return result
@@ -323,9 +327,9 @@ class DisgenetApi:
         """
         Returns Gene-Disease Associations.
 
-        @source (returned field): Curated source names derived from
-        scoreBreakdown.components.curated.sources; may contain multiple
-        values.
+        @source (returned field): Source names derived from
+        scoreBreakdown, collected across all of its components and
+        deduplicated; may contain multiple values.
 
         @gene_ncbi_id / @gene_ensembl_id / @gene_symbol: Union[str, List[str]]
             Gene identifier(s) in the respective vocabulary, up to 100.
@@ -337,9 +341,8 @@ class DisgenetApi:
             Source of the GDA.
         @min_score/@max_score, @min_ei/@max_ei, @min_dsi/@max_dsi,
         @min_dpi/@max_dpi, @min_pli/@max_pli: float
-            Filters on the API's raw score field, which is not bounded to
-            [0,1] (unlike normalized_score, which has no separate filter
-            param). ei/dsi/dpi ranges are in [0,1].
+            Score ranges, in [0,1]. min_score/max_score filter on
+            normalized_score, matching the returned score field.
         @type: str
             DisGeNET Disease Type ("disease", "phenotype", "group").
         @dis_class_list: Union[str, List[str]]
@@ -463,7 +466,7 @@ class DisgenetApi:
                 self._get_string(entry.get("el")),
                 self._get_int(entry.get("yearInitial")),
                 self._get_int(entry.get("yearFinal")),
-                self._get_curated_sources(entry),
+                self._get_sources(entry),
             )
 
         return result
@@ -652,7 +655,8 @@ class DisgenetApi:
         ],
     ):
         """
-        Returns Disease-Disease Associations between disease_1 and disease_2.
+        Returns Disease-Disease Associations for disease_1, optionally
+        restricted to the diseases given in disease_2.
         The API returns gene-sharing and variant-sharing metrics together
         in a single query, but a given pair only carries the metrics it
         actually has: a pair that shares genes but no variants comes back
@@ -662,7 +666,7 @@ class DisgenetApi:
         against None before doing arithmetic on either jaccard field.
 
         @disease_1: Union[str, List[str]]
-        Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
+            Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
         @disease_2: Union[str, List[str]], optional
             Disease id(s) with vocabulary prefix. If omitted, returns all
             diseases sharing genes/variants with disease_1.
@@ -884,18 +888,39 @@ class DisgenetApi:
 
         return str_obj
 
-    def _get_curated_sources(self, entry) -> Optional[Tuple[str]]:
+    def _get_sources(self, entry) -> Optional[Tuple[str]]:
         """
-    Returns curated source names derived from scoreBreakdown, if present.
+        Returns source names derived from scoreBreakdown, if present.
 
-    @entry : dict
-        A single record from a /summary or /entity response.
-    """
+        Collects every component (curated, clinical, inferred, models,
+        literature, biobank) rather than the curated ones alone, which
+        stays closer to the old API's `source` field; callers wanting a
+        single component can filter downstream.
+
+        A component may be present but null (biobank commonly is), and
+        the same source can appear under more than one component
+        (TEXTMINING_MODELS shows up under both models and literature), so
+        the union is deduplicated. It is also sorted to keep the value
+        stable across runs, since these tuples end up in namedtuples that
+        disgenet_annotations() collects into a set.
+
+        @entry : dict
+            A single record from a /summary response.
+        """
         breakdown = entry.get("scoreBreakdown")
         if not breakdown:
             return None
-        sources = breakdown[0].get("components", {}).get("curated", {}).get("sources")
-        return tuple(sources) if sources else None
+
+        components = breakdown[0].get("components") or {}
+        sources = set()
+
+        for component in components.values():
+            if not component:
+                continue
+
+            sources.update(component.get("sources") or ())
+
+        return tuple(sorted(sources)) if sources else None
 
 
 @DisgenetApi._delete_cache
@@ -903,10 +928,16 @@ def variant_gene_mappings(
     api: "DisgenetApi",
     gene_ncbi_ids: List[str],
     batch_size: int = 10,
-) -> Dict[str, "VariantGeneMapping"]:
+) -> Tuple[Dict[str, "VariantGeneMapping"], List[List[str]]]:
     """
     Builds a {snpId: [VariantGeneMapping(geneId, geneSymbol, sourceIds),
     ...]} mapping by querying the DisGeNET API.
+
+    Returns a (mapping, failed_batches) tuple. A batch whose pagination
+    is cut short by a retrieval error - an expired quota mid-run being
+    the common case - is appended to failed_batches, so a caller can
+    tell a partial result from a complete one instead of silently
+    building on truncated input.
 
     Requires a list of known NCBI Gene IDs to query against - e.g. from
     uniprot_adapter.py's xref_geneid field (same source used for
@@ -935,6 +966,7 @@ def variant_gene_mappings(
     )
 
     mapping = dict()
+    failed_batches = []
 
     for i in range(0, len(gene_ncbi_ids), batch_size):
         batch = gene_ncbi_ids[i : i + batch_size]
@@ -953,7 +985,12 @@ def variant_gene_mappings(
                 # A real error occurred (auth failure, bad response, etc.),
                 # not just an empty final page — stop this batch rather than
                 # silently treating a failure as "pagination complete".
-                _log("DisGeNET: stopping pagination for this batch due to a retrieval error.")
+                _log(
+                    f"DisGeNET: stopping pagination for batch {batch} "
+                    f"at page {page_number} due to a retrieval error; "
+                    f"results for these ids are incomplete."
+                )
+                failed_batches.append(batch)
                 break
 
             if not result:
@@ -980,6 +1017,11 @@ def variant_gene_mappings(
                     pair = (gene_id_str, gene_symbol)
 
                     if pair in existing_pairs:
+                        # variantToGenes is variant-level data: the same
+                        # variant reached through a different gene query
+                        # comes back with an identical list, sources
+                        # included, so the skipped record has nothing to
+                        # merge in - verified against the API.
                         continue
 
                     mapping[snp_id].append(
@@ -998,7 +1040,7 @@ def variant_gene_mappings(
 
             page_number += 1
 
-    return mapping
+    return mapping, failed_batches
 
 
 @DisgenetApi._delete_cache
@@ -1006,10 +1048,16 @@ def disease_id_mappings(
     api: "DisgenetApi",
     mondo_ids: List[str],
     batch_size: int = 10,
-) -> Dict[str, "DiseaseIdMapping"]:
+) -> Tuple[Dict[str, "DiseaseIdMapping"], List[List[str]]]:
     """
     Builds a {diseaseId: DiseaseIdMapping(name, vocabularies)} mapping by
     querying the DisGeNET API.
+
+    Returns a (mapping, failed_batches) tuple. A batch whose pagination
+    is cut short by a retrieval error - an expired quota mid-run being
+    the common case - is appended to failed_batches, so a caller can
+    tell a partial result from a complete one instead of silently
+    building on truncated input.
 
     Requires a list of known MONDO disease IDs to query against - e.g.
     from disease_adapter.py's MONDO ontology download. Each ID must be in
@@ -1056,6 +1104,7 @@ def disease_id_mappings(
     )
 
     mapping = dict()
+    failed_batches = []
 
     for i in range(0, len(mondo_ids), batch_size):
         batch = mondo_ids[i : i + batch_size]
@@ -1074,7 +1123,12 @@ def disease_id_mappings(
                 # A real error occurred (auth failure, bad response, etc.),
                 # not just an empty final page — stop this batch rather than
                 # silently treating a failure as "pagination complete".
-                _log("DisGeNET: stopping pagination for this batch due to a retrieval error.")
+                _log(
+                    f"DisGeNET: stopping pagination for batch {batch} "
+                    f"at page {page_number} due to a retrieval error; "
+                    f"results for these ids are incomplete."
+                )
+                failed_batches.append(batch)
                 break
 
             if not result:
@@ -1123,7 +1177,7 @@ def disease_id_mappings(
 
             page_number += 1
 
-    return mapping
+    return mapping, failed_batches
 
 
 @DisgenetApi._delete_cache
@@ -1132,10 +1186,16 @@ def disgenet_annotations(
     gene_ncbi_ids: List[str],
     dataset: str = "curated",
     batch_size: int = 10,
-) -> Dict[str, set]:
+) -> Tuple[Dict[str, set], List[List[str]]]:
     """
     Builds a {uniprot_id: {DisGeNetAnnotation(...), ...}} mapping by
     querying the DisGeNET API.
+
+    Returns a (mapping, failed_batches) tuple. A batch whose pagination
+    is cut short by a retrieval error - an expired quota mid-run being
+    the common case - is appended to failed_batches, so a caller can
+    tell a partial result from a complete one instead of silently
+    building on truncated input.
 
     Requires a list of known NCBI Gene IDs to query against - e.g. from
     uniprot_adapter.py's xref_geneid field. No gene-symbol-to-UniProt
@@ -1171,7 +1231,7 @@ def disgenet_annotations(
             "'all' are mapped to the API's source filter; 'literature' "
             "and 'befree' have no clear equivalent in the source list."
         )
-        return {}
+        return {}, []
 
     source = dataset_source_map[dataset]
 
@@ -1190,6 +1250,7 @@ def disgenet_annotations(
     )
 
     data = collections.defaultdict(set)
+    failed_batches = []
 
     for i in range(0, len(gene_ncbi_ids), batch_size):
         batch = gene_ncbi_ids[i : i + batch_size]
@@ -1211,7 +1272,12 @@ def disgenet_annotations(
                 # A real error occurred (auth failure, bad response, etc.),
                 # not just an empty final page — stop this batch rather than
                 # silently treating a failure as "pagination complete".
-                _log("DisGeNET: stopping pagination for this batch due to a retrieval error.")
+                _log(
+                    f"DisGeNET: stopping pagination for batch {batch} "
+                    f"at page {page_number} due to a retrieval error; "
+                    f"results for these ids are incomplete."
+                )
+                failed_batches.append(batch)
                 break
 
             if not result:
@@ -1233,7 +1299,7 @@ def disgenet_annotations(
                 nof_snps = entry.get("numDBSNPsupportingAssociation")
 
                 
-                record_source = api._get_curated_sources(entry)
+                record_source = api._get_sources(entry)
 
                 annotation = DisGeNetAnnotation(
                     disease,
@@ -1256,4 +1322,4 @@ def disgenet_annotations(
 
             page_number += 1
 
-    return dict(data)
+    return dict(data), failed_batches

--- a/bccb/disgenet_local.py
+++ b/bccb/disgenet_local.py
@@ -25,7 +25,6 @@
 
 import os
 import collections
-import csv
 import json
 from getpass import getpass
 
@@ -40,7 +39,7 @@ _log = _logger._log
 
 
 class DisgenetApi:
-    
+
     _name = "DisGeNET"
     _api_url = urls.urls["disgenet"]["api_url"]
     _authenticated: bool = False
@@ -55,15 +54,16 @@ class DisgenetApi:
         if self._authenticated and self._api_key != None:
             return True
 
-        print(f"Authorizing in {self._name} API...")
+        _log(f"Authorizing in {self._name} API...")
         # DisGeNET auth is a static per-user API key, no token exchange needed.
         # Checks DISGENET_API_KEY env var first so long batch runs aren't
         # interrupted by a prompt; falls back to getpass otherwise.
         api_key: str = os.environ.get("DISGENET_API_KEY") or getpass("API Key: ")
 
         if not api_key:
-            print(f"No API key provided for {self._name} API.")
+            _log(f"No API key provided for {self._name} API.")
             self._authenticated = False
+            self._api_key = None
             return False
 
         self._api_key = api_key
@@ -153,7 +153,7 @@ class DisgenetApi:
         @source (returned field): Source names derived from
         scoreBreakdown, collected across all of its components and
         deduplicated; may contain multiple values.
-        
+
 
         @variant: Union[str, List[str]]
             Variant (dbSNP Identifier) or list of variants, up to 100.
@@ -260,7 +260,7 @@ class DisgenetApi:
                 self._get_string(entry.get("diseaseUMLSCUI")),
                 self._get_string(entry.get("diseaseName")),
                 tuple(entry["diseaseClasses_DO"]) if entry.get("diseaseClasses_DO") else None,
-                tuple(entry["diseaseClasses_HPO"]) if entry.get("diseaseClasses_HPO") else None, 
+                tuple(entry["diseaseClasses_HPO"]) if entry.get("diseaseClasses_HPO") else None,
                 tuple(entry["diseaseClasses_MSH"]) if entry.get("diseaseClasses_MSH") else None,
                 tuple(entry["diseaseClasses_UMLS_ST"]) if entry.get("diseaseClasses_UMLS_ST") else None,
                 self._get_string(entry.get("diseaseType")).strip("[]") if entry.get("diseaseType") else None,
@@ -273,7 +273,7 @@ class DisgenetApi:
 
         return result
 
-    
+
     # /gda/summary takes every identifier type (gene, disease, uniprot, source, ...)
     # as an optional query parameter on a single call, so one function covers all
     # identifier types and filters at once.
@@ -471,8 +471,8 @@ class DisgenetApi:
 
         return result
 
-    
-        
+
+
 
     def get_vda_evidence(
         self,
@@ -549,7 +549,7 @@ class DisgenetApi:
         return result
 
 
-    
+
     def get_gda_evidence(
         self,
         gene_ncbi_id: Union[str, List[str]] = None,
@@ -617,8 +617,8 @@ class DisgenetApi:
         result, _ = self._retrieve_data(url, get_params)
 
         return result
-    
-    
+
+
 
     def get_dda(
         self,
@@ -739,7 +739,7 @@ class DisgenetApi:
                 tuple(entry["disease2_Classes_HPO"]) if entry.get("disease2_Classes_HPO") else None,
                 tuple(entry["disease2_Classes_MSH"]) if entry.get("disease2_Classes_MSH") else None,
                 tuple(entry["disease2_Classes_UMLS_ST"]) if entry.get("disease2_Classes_UMLS_ST") else None,
-            
+
                 self._get_float(entry.get("jaccard_genes")),
                 self._get_float(entry.get("pvalue_jaccard_genes")),
                 self._get_float(entry.get("jaccard_variants")),
@@ -756,8 +756,8 @@ class DisgenetApi:
             )
 
         return result
-   
-    
+
+
 
     def _list_to_str(
         self, list_obj: List[str], name: str, limit: Optional[int] = None
@@ -873,21 +873,6 @@ class DisgenetApi:
 
         return obj
 
-    def _get_tuple(self, str_obj: str, delim: str) -> Tuple[str]:
-        """
-        Returns a splitted tuple with given delimiter
-
-        @str_obj : str
-            String object to be processed
-        @delim : str
-            Char to split the str_obj
-        """
-
-        if str_obj != None and not isinstance(str_obj, tuple):
-            return tuple([item.strip() for item in str_obj.split(delim)])
-
-        return str_obj
-
     def _get_sources(self, entry) -> Optional[Tuple[str]]:
         """
         Returns source names derived from scoreBreakdown, if present.
@@ -928,7 +913,7 @@ def variant_gene_mappings(
     api: "DisgenetApi",
     gene_ncbi_ids: List[str],
     batch_size: int = 10,
-) -> Tuple[Dict[str, "VariantGeneMapping"], List[List[str]]]:
+) -> Tuple[Dict[str, List["VariantGeneMapping"]], List[List[str]]]:
     """
     Builds a {snpId: [VariantGeneMapping(geneId, geneSymbol, sourceIds),
     ...]} mapping by querying the DisGeNET API.
@@ -951,9 +936,7 @@ def variant_gene_mappings(
     @gene_ncbi_ids: List[str]
         Known NCBI Gene (Entrez) IDs to query, e.g. ["672", "675", ...].
     @batch_size: int
-        Number of gene IDs to send per request. Kept small (10) by
-        default to stay safe under TRIAL account limits while testing;
-        raise this once running under a full academic account.
+        Number of gene IDs to send per request.
     """
 
     VariantGeneMapping = collections.namedtuple(
@@ -1081,9 +1064,7 @@ def disease_id_mappings(
     @mondo_ids: List[str]
         Known MONDO disease IDs to query, e.g. ["MONDO_0007254", ...].
     @batch_size: int
-        Number of disease IDs to send per request. Kept small (10) by
-        default to stay safe under TRIAL account limits while testing;
-        raise this once running under a full academic account.
+        Number of disease IDs to send per request.
     """
 
     Vocabulary = collections.namedtuple(
@@ -1215,9 +1196,7 @@ def disgenet_annotations(
         Only "curated" and "all" are supported (mapped to
         source=["CURATED"] and no source filter, respectively).
     @batch_size: int
-        Number of gene IDs to send per request. Kept small (10) by
-        default to stay safe under TRIAL account limits while testing;
-        raise this once running under a full academic account.
+        Number of gene IDs to send per request.
     """
 
     dataset_source_map = {
@@ -1298,7 +1277,7 @@ def disgenet_annotations(
                 nof_pmids = entry.get("numPMIDs")
                 nof_snps = entry.get("numDBSNPsupportingAssociation")
 
-                
+
                 record_source = api._get_sources(entry)
 
                 annotation = DisGeNetAnnotation(

--- a/bccb/disgenet_local.py
+++ b/bccb/disgenet_local.py
@@ -78,8 +78,7 @@ class DisgenetApi:
         if already haven't.
 
         Wraps _retrieve_data, whose callers unpack a (payload, paging)
-        tuple, so a failed authentication has to return that shape too
-        rather than a bare None.
+        tuple, so a failed authentication has to return that shape too.
         """
 
         def wrapper(self, *args, **kwargs):
@@ -147,8 +146,8 @@ class DisgenetApi:
         """
         Returns Variant-Disease Associations.
 
-        @diseaseClasses_HPO: Usually None; kept to avoid dropping this
-        classification when it is populated for a given variant/gene.
+        @diseaseClasses_HPO (returned field): Populated only for some
+        variant/gene combinations; None otherwise.
 
         @source (returned field): Source names derived from
         scoreBreakdown, collected across all of its components and
@@ -274,9 +273,6 @@ class DisgenetApi:
         return result
 
 
-    # /gda/summary takes every identifier type (gene, disease, uniprot, source, ...)
-    # as an optional query parameter on a single call, so one function covers all
-    # identifier types and filters at once.
     def get_gda_summary(
         self,
         gene_ncbi_id: Union[str, List[str]] = None,
@@ -661,8 +657,7 @@ class DisgenetApi:
         in a single query, but a given pair only carries the metrics it
         actually has: a pair that shares genes but no variants comes back
         with jaccard_variants (and pvalue_jaccard_variants) set to None.
-        This is common rather than exceptional - in a 636-record sample
-        jaccard_variants was None in 382 of them. Callers must guard
+        This is common rather than exceptional, so callers must guard
         against None before doing arithmetic on either jaccard field.
 
         @disease_1: Union[str, List[str]]
@@ -788,7 +783,6 @@ class DisgenetApi:
 
     # Guards against calling the API without a valid key.
     @_if_authenticated
-    #@_delete_cache
     def _retrieve_data(
         self, url: str, get_params: Union[List[str], Dict[str, str]]
     ) -> Tuple[Optional[List[Dict[str, str]]], Optional[Dict[str, str]]]:
@@ -878,9 +872,8 @@ class DisgenetApi:
         Returns source names derived from scoreBreakdown, if present.
 
         Collects every component (curated, clinical, inferred, models,
-        literature, biobank) rather than the curated ones alone, which
-        stays closer to the old API's `source` field; callers wanting a
-        single component can filter downstream.
+        literature, biobank); callers wanting a single component can
+        filter downstream.
 
         A component may be present but null (biobank commonly is), and
         the same source can appear under more than one component
@@ -928,8 +921,8 @@ def variant_gene_mappings(
     uniprot_adapter.py's xref_geneid field (same source used for
     disgenet_annotations()). Queries /entity/variant using gene_ncbi_id,
     which returns each matching variant's own variantToGenes field - a
-    list of {geneNcbiID, symbolOfGene, geneEnsemblID, sources} already
-    grouped per variant, so no manual grouping across rows is needed.
+    list of {geneNcbiID, symbolOfGene, geneEnsemblID, sources} grouped
+    per variant.
 
     @api: DisgenetApi
         An already-authenticated DisgenetApi instance.
@@ -1004,7 +997,7 @@ def variant_gene_mappings(
                         # variant reached through a different gene query
                         # comes back with an identical list, sources
                         # included, so the skipped record has nothing to
-                        # merge in - verified against the API.
+                        # merge in.
                         continue
 
                     mapping[snp_id].append(
@@ -1049,8 +1042,8 @@ def disease_id_mappings(
     This is a standalone function (not a DisgenetApi method); it takes an
     already-authenticated DisgenetApi instance as a parameter and calls
     _retrieve_data directly rather than going through get_gda_summary(),
-    because get_gda_summary()'s narrowed output doesn't include
-    diseaseVocabularies, which is exactly the field this function needs.
+    because get_gda_summary() does not return diseaseVocabularies, which
+    is the field this function needs.
 
     Note on data shape: /gda/summary returns one row per matching gene
     for a queried disease, and every row repeats the same disease-level
@@ -1179,13 +1172,13 @@ def disgenet_annotations(
     building on truncated input.
 
     Requires a list of known NCBI Gene IDs to query against - e.g. from
-    uniprot_adapter.py's xref_geneid field. No gene-symbol-to-UniProt
-    translation is needed: the API returns UniProt IDs directly in
-    geneProteinStrIDs, so those are read straight from the response.
+    uniprot_adapter.py's xref_geneid field. The API returns UniProt IDs
+    directly in geneProteinStrIDs, so those are read straight from the
+    response.
 
     This calls _retrieve_data directly rather than get_gda_summary(),
-    because get_gda_summary()'s narrowed output doesn't include numPMIDs
-    or numDBSNPsupportingAssociation, which map to this function's
+    because get_gda_summary() does not return numPMIDs or
+    numDBSNPsupportingAssociation, which map to this function's
     nof_pmids/nof_snps fields.
 
     @api: DisgenetApi

--- a/bccb/disgenet_local.py
+++ b/bccb/disgenet_local.py
@@ -58,28 +58,15 @@ class DisgenetApi:
             return True
 
         print(f"Authorizing in {self._name} API...")
-        e_mail: str = input("E-mail: ")
-        password: str = getpass("Password: ")
-        
-        url: str = f"{self._api_url}/auth/"
-        post_params: dict[str, str] = {"email": e_mail, "password": password}
-        headers: dict[str, str] = {
-            "accept: */*",
-            "Content-Type: application/x-www-form-urlencoded",
-        }
+        # DisGeNET migrated from email/password login (returning a session
+        # token) to a static per-user API key generated on their website.
+        # There is no /auth/ endpoint to call anymore, so we just prompt
+        # for the key and store it directly instead of making a POST
+        # request and parsing a token from the response.
+        api_key: str = getpass("API Key: ")
 
-        c = curl.Curl(url=url, post=post_params, req_headers=headers)
-        response: int = c.status
-
-        if response == 200 or response == 0:
-            result: dict[str, str] = json.loads(c.result)
-            self._authenticated = True
-            self._api_key = result["token"]
-            print("Authorization successful.")
-
-        elif response == 404:
-            self._authenticated = False
-            self._api_key = None
+        self._api_key = api_key
+        self._authenticated = True
 
         return self._authenticated and (self._api_key != None)
 
@@ -95,7 +82,7 @@ class DisgenetApi:
                 return f(self, *args, **kwargs)
 
             else:
-                print("Failure in authorization, check your credentials.")
+                _log("DisGeNET failure in authorization, check your credentials.")
 
         return wrapper
 
@@ -111,1433 +98,114 @@ class DisgenetApi:
 
         return wrapper
 
-    def get_ddas_that_share_genes(
-        self,
-        disease: Union[str, List[str]],
-        vocabulary: str = None,
-        source: str = None,
-        p_value: float = None,
-        limit: int = 10,
-    ) -> NamedTuple(
-        "DiseaseDiseaseAssociation",
-        [
-            ("disease1_name", str),
-            ("disease2_name", str),
-            ("disease1_ngenes", int),
-            ("disease2_ngenes", int),
-            ("disease1_disease_class", Tuple[str]),
-            ("disease2_disease_class", Tuple[str]),
-            ("disease1_disease_class_name", Tuple[str]),
-            ("disease2_disease_class_name", Tuple[str]),
-            ("jaccard_genes", float),
-            ("pvalue_jaccard_genes", float),
-            ("source", str),
-            ("ngenes1", int),
-            ("ngenes2", int),
-            ("ngenes", int),
-            ("nvariants1", int),
-            ("nvariants2", int),
-            ("diseaseid1", str),
-            ("diseaseid2", str),
-        ],
-    ):
-        """
-        Returns Disease-Disease Associations with given query.
+    # get_ddas_that_share_genes() and get_ddas_that_share_variants() were
+    # removed: the new DisGeNET DDA API has a single /dda endpoint that
+    # always returns both gene-sharing and variant-sharing metrics
+    # together in one query, so the separate genes/variants split no
+    # longer applies.
 
-        @disease: Union[str, List[str]]
-            if vocabulary is given:
-                Disease id (ICD9CM, ICD10,MeSH, OMIM, DO, EFO,
-                NCI, HPO, MONDO, or ORDO identifier) or list of disease ids up to 100.
-            else:
-                Disease id (UMLS CUI) or list of disease ids up to 100.
-        @vocabulary: str
-            Disease Vocabulary.
-            Available values : icd9cm, icd10, mesh, omim, do, efo,
-            nci, hpo, mondo, ordo
-        @source: str
-            Source of the DDA.
-            Available values : CURATED, INFERRED, ANIMAL_MODELS, ALL, BEFREE,
-            CGI, CLINGEN, CLINVAR, CTD_human, CTD_mouse, CTD_rat, GENOMICS_ENGLAND,
-            GWASCAT, GWASDB, HPO, LHGDN, MGD, ORPHANET, PSYGENET, RGD, UNIPROT
-        @p_value: float
-            p value associated to the Jaccard Index based on the shared genes.
-        @limit: int
-            Number of associated diseases to retrieve.
-            Default value : 10
-        """
-
-        return self._get_ddas(
-            disease=disease,
-            share="genes",
-            vocabulary=vocabulary,
-            source=source,
-            p_value=p_value,
-            limit=limit,
-        )
-
-    def get_ddas_that_share_variants(
-        self,
-        disease: Union[str, List[str]],
-        vocabulary: str = None,
-        source: str = None,
-        p_value: float = None,
-        limit: int = 10,
-    ) -> NamedTuple(
-        "DiseaseDiseaseAssociation",
-        [
-            ("disease1_name", str),
-            ("disease2_name", str),
-            ("disease1_nvariants", int),
-            ("disease2_nvariants", int),
-            ("disease1_disease_class", Tuple[str]),
-            ("disease2_disease_class", Tuple[str]),
-            ("disease1_disease_class_name", Tuple[str]),
-            ("disease2_disease_class_name", Tuple[str]),
-            ("jaccard_variants", float),
-            ("pvalue_jaccard_variants", float),
-            ("source", str),
-            ("ngenes1", int),
-            ("ngenes2", int),
-            ("nvariants", int),
-            ("nvariants1", int),
-            ("nvariants2", int),
-            ("diseaseid1", str),
-            ("diseaseid2", str),
-        ],
-    ):
-        """
-        Returns Disease-Disease Associations with given query.
-
-        @disease: Union[str, List[str]]
-            if vocabulary is given:
-                Disease id (ICD9CM, ICD10,MeSH, OMIM, DO, EFO,
-                NCI, HPO, MONDO, or ORDO identifier) or list of disease ids up to 100.
-            else:
-                Disease id (UMLS CUI) or list of disease ids up to 100.
-        @vocabulary: str
-            Disease Vocabulary.
-            Available values : icd9cm, icd10, mesh, omim, do, efo,
-            nci, hpo, mondo, ordo
-        @source: str
-            Source of the DDA.
-            Available values : CURATED, INFERRED, ANIMAL_MODELS, ALL, BEFREE,
-            CGI, CLINGEN, CLINVAR, CTD_human, CTD_mouse, CTD_rat, GENOMICS_ENGLAND,
-            GWASCAT, GWASDB, HPO, LHGDN, MGD, ORPHANET, PSYGENET, RGD, UNIPROT
-        @p_value: float
-            p value associated to the Jaccard Index based on the shared genes.
-        @limit: int
-            Number of associated diseases to retrieve.
-            Default value : 10
-        """
-
-        return self._get_ddas(
-            disease=disease,
-            share="variants",
-            vocabulary=vocabulary,
-            source=source,
-            p_value=p_value,
-            limit=limit,
-        )
-
-    def get_vdas_by_variants(
-        self,
-        variant: Union[str, List[str]],
-        gene: Union[str, List[str]] = None,
-        disease: Union[str, List[str]] = None,
-        source: str = None,
-        min_score: float = None,
-        max_score: float = None,
-        min_ei: float = None,
-        max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
-        min_dsi: float = None,
-        max_dsi: float = None,
-        min_dpi: float = None,
-        max_dpi: float = None,
-        limit: int = None,
-    ) -> NamedTuple(
-        "VariantDiseaseAssociation",
-        [
-            ("variantid", str),
-            ("gene_symbol", str),
-            ("variant_dsi", float),
-            ("variant_dpi", float),
-            ("variant_consequence_type", str),
-            ("diseaseid", str),
-            ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
-            ("disease_type", str),
-            ("disease_semantic_type", str),
-            ("score", float),
-            ("ei", float),
-            ("year_initial", int),
-            ("year_final", int),
-            ("source", str),
-        ],
-    ):
-        """
-        Returns Variant-Disease Associations by variant(s).
-
-        @variant: Union[str, List[str]]
-            Variant (dbSNP Identifier) or list of variants.
-        @disease: Union[str, List[str]]
-            if vocabulary is given:
-                Disease id (ICD9CM, ICD10, MeSH, OMIM, DO, EFO, NCI, HPO, MONDO,
-                or ORDO identifier) or list of disease ids to filter the results.
-            else:
-                Disease id (UMLS CUI) or list of diseases to filter the results.
-        @gene: Union[str, List[str]]
-            Gene (NCBI Entrez Identifier or HGNC Symbol) or list of genes to filter the results.
-        @source: str
-            Source of the VDA.
-            Available values : CURATED, BEFREE, ALL, CLINVAR, GWASCAT, GWASDB, UNIPROT
-        @min_score: float
-            Min value of the variant-disease score range.
-        @max_score: float
-            Max value of the variant-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the variant.
-        @max_dsi: float
-            Max value of the DSI range for the variant.
-        @min_dpi: float
-            Min value of the DPI range for the variant.
-        @max_dpi: float
-            Max value of the DPI range for the variant.
-        @limit: int
-            Number of VDAs to retrieve.
-        """
-
-        gene = self._list_to_str(gene, "Gene ID")
-        disease = self._list_to_str(disease, "Disease ID")
-        variant = self._list_to_str(variant, "Variant ID", limit=100)
-
-        return self._get_vdas(
-            gene=gene,
-            disease=disease,
-            variant=variant,
-            vocabulary=None,
-            by="variant",
-            source=source,
-            min_score=min_score,
-            max_score=max_score,
-            min_ei=min_ei,
-            max_ei=max_ei,
-            disease_type=disease_type,
-            disease_class=disease_class,
-            min_dsi=min_dsi,
-            max_dsi=max_dsi,
-            min_dpi=min_dpi,
-            max_dpi=max_dpi,
-            limit=limit,
-        )
-
-    def get_vdas_by_genes(
-        self,
-        gene: Union[str, List[str]],
-        disease: Union[str, List[str]] = None,
-        variant: Union[str, List[str]] = None,
-        source: str = None,
-        min_score: float = None,
-        max_score: float = None,
-        min_ei: float = None,
-        max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
-        min_dsi: float = None,
-        max_dsi: float = None,
-        min_dpi: float = None,
-        max_dpi: float = None,
-        limit: int = None,
-    ) -> NamedTuple(
-        "VariantDiseaseAssociation",
-        [
-            ("variantid", str),
-            ("gene_symbol", str),
-            ("variant_dsi", float),
-            ("variant_dpi", float),
-            ("variant_consequence_type", str),
-            ("diseaseid", str),
-            ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
-            ("disease_type", str),
-            ("disease_semantic_type", str),
-            ("score", float),
-            ("ei", float),
-            ("year_initial", int),
-            ("year_final", int),
-            ("source", str),
-        ],
-    ):
-        """
-        Returns Variant-Disease Associations by gene(s).
-
-        @gene: Union[str, List[str]]
-            Gene (NCBI Entrez Identifier or HGNC Symbol) or list of genes.
-        @variant: Union[str, List[str]]
-            Variant (dbSNP Identifier) or list of variants to filter the results.
-        @disease: Union[str, List[str]]
-            if vocabulary is given:
-                Disease id (ICD9CM, ICD10, MeSH, OMIM, DO, EFO, NCI, HPO, MONDO,
-                or ORDO identifier) or list of disease ids to filter the results.
-            else:
-                Disease id (UMLS CUI) or list of diseases to filter the results.
-        @source: str
-            Source of the VDA.
-            Available values : CURATED, BEFREE, ALL, CLINVAR, GWASCAT, GWASDB, UNIPROT
-        @min_score: float
-            Min value of the variant-disease score range.
-        @max_score: float
-            Max value of the variant-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the variant.
-        @max_dsi: float
-            Max value of the DSI range for the variant.
-        @min_dpi: float
-            Min value of the DPI range for the variant.
-        @max_dpi: float
-            Max value of the DPI range for the variant.
-        @limit: int
-            Number of VDAs to retrieve.
-        """
-
-        gene = self._list_to_str(gene, "Gene ID", limit=100)
-        disease = self._list_to_str(disease, "Disease ID")
-        variant = self._list_to_str(variant, "Variant ID")
-
-        return self._get_vdas(
-            gene=gene,
-            disease=disease,
-            variant=variant,
-            vocabulary=None,
-            by="gene",
-            source=source,
-            min_score=min_score,
-            max_score=max_score,
-            min_ei=min_ei,
-            max_ei=max_ei,
-            disease_type=disease_type,
-            disease_class=disease_class,
-            min_dsi=min_dsi,
-            max_dsi=max_dsi,
-            min_dpi=min_dpi,
-            max_dpi=max_dpi,
-            limit=limit,
-        )
-
-    def get_vdas_by_diseases(
-        self,
-        disease: Union[str, List[str]],
-        gene: Union[str, List[str]] = None,
-        variant: Union[str, List[str]] = None,
-        vocabulary: str = None,
-        source: str = None,
-        min_score: float = None,
-        max_score: float = None,
-        min_ei: float = None,
-        max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
-        min_dsi: float = None,
-        max_dsi: float = None,
-        min_dpi: float = None,
-        max_dpi: float = None,
-        limit: int = None,
-    ) -> NamedTuple(
-        "VariantDiseaseAssociation",
-        [
-            ("variantid", str),
-            ("gene_symbol", str),
-            ("variant_dsi", float),
-            ("variant_dpi", float),
-            ("variant_consequence_type", str),
-            ("diseaseid", str),
-            ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
-            ("disease_type", str),
-            ("disease_semantic_type", str),
-            ("score", float),
-            ("ei", float),
-            ("year_initial", int),
-            ("year_final", int),
-            ("source", str),
-        ],
-    ):
-        """
-        Returns Variant-Disease Associations disease(s).
-
-        @disease: Union[str, List[str]]
-            if vocabulary is given:
-                Disease id (ICD9CM, ICD10, MeSH, OMIM, DO, EFO, NCI, HPO, MONDO,
-                or ORDO identifier) or list of disease ids up to 100.
-            else:
-                Disease id (UMLS CUI) or list of diseases up to 100.
-        @vocabulary: str
-            Disease Vocabulary.
-            Available values : icd9cm, icd10, mesh, omim, do, efo, nci, hpo, mondo, ordo
-        @variant: Union[str, List[str]]
-            Variant (dbSNP Identifier) or list of variants to filter the results.
-        @gene: Union[str, List[str]]
-            Gene (NCBI Entrez Identifier or HGNC Symbol) or list of genes to filter the results.
-        @source: str
-            Source of the VDA.
-            Available values : CURATED, BEFREE, ALL, CLINVAR, GWASCAT, GWASDB, UNIPROT
-        @min_score: float
-            Min value of the variant-disease score range.
-        @max_score: float
-            Max value of the variant-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the variant.
-        @max_dsi: float
-            Max value of the DSI range for the variant.
-        @min_dpi: float
-            Min value of the DPI range for the variant.
-        @max_dpi: float
-            Max value of the DPI range for the variant.
-        @limit: int
-            Number of VDAs to retrieve.
-        """
-
-        gene = self._list_to_str(gene, "Gene ID")
-        disease = self._list_to_str(disease, "Disease ID", limit=100)
-        variant = self._list_to_str(variant, "Variant ID")
-
-        return self._get_vdas(
-            gene=gene,
-            disease=disease,
-            variant=variant,
-            vocabulary=vocabulary,
-            by="disease",
-            source=source,
-            min_score=min_score,
-            max_score=max_score,
-            min_ei=min_ei,
-            max_ei=max_ei,
-            disease_type=disease_type,
-            disease_class=disease_class,
-            min_dsi=min_dsi,
-            max_dsi=max_dsi,
-            min_dpi=min_dpi,
-            max_dpi=max_dpi,
-            limit=limit,
-        )
-
-    def get_vdas_by_source(
-        self,
-        source: str,
-        gene: Union[str, List[str]] = None,
-        disease: Union[str, List[str]] = None,
-        variant: Union[str, List[str]] = None,
-        vocabulary: str = None,
-        by: str = None,
-        min_score: float = None,
-        max_score: float = None,
-        min_ei: float = None,
-        max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
-        min_dsi: float = None,
-        max_dsi: float = None,
-        min_dpi: float = None,
-        max_dpi: float = None,
-        limit: int = None,
-    ) -> NamedTuple(
-        "VariantDiseaseAssociation",
-        [
-            ("variantid", str),
-            ("gene_symbol", str),
-            ("variant_dsi", float),
-            ("variant_dpi", float),
-            ("variant_consequence_type", str),
-            ("diseaseid", str),
-            ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
-            ("disease_type", str),
-            ("disease_semantic_type", str),
-            ("score", float),
-            ("ei", float),
-            ("year_initial", int),
-            ("year_final", int),
-            ("source", str),
-        ],
-    ):
-        """
-        Returns Variant-Disease Associations by source.
-
-        @source: str
-            Source of the VDA.
-            Available values : CURATED, BEFREE, ALL, CLINVAR, GWASCAT, GWASDB, UNIPROT
-        @disease: Union[str, List[str]]
-            Disease id (UMLS CUI) or list of diseases to filter the results..
-        @variant: Union[str, List[str]]
-            Variant (dbSNP Identifier) or list of variants to filter the results..
-        @gene: Union[str, List[str]]
-            Gene (NCBI Entrez Identifier or HGNC Symbol) or list of genes to filter the results..
-        @min_score: float
-            Min value of the variant-disease score range.
-        @max_score: float
-            Max value of the variant-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the variant.
-        @max_dsi: float
-            Max value of the DSI range for the variant.
-        @min_dpi: float
-            Min value of the DPI range for the variant.
-        @max_dpi: float
-            Max value of the DPI range for the variant.
-        @limit: int
-            Number of VDAs to retrieve.
-        """
-
-        disease = self._list_to_str(disease, "Disease ID")
-        variant = self._list_to_str(variant, "Variant ID")
-        gene = self._list_to_str(gene, "Gene ID")
-
-        return self._get_vdas(
-            gene=gene,
-            disease=disease,
-            variant=variant,
-            vocabulary=vocabulary,
-            by="source",
-            source=source,
-            min_score=min_score,
-            max_score=max_score,
-            min_ei=min_ei,
-            max_ei=max_ei,
-            disease_type=disease_type,
-            disease_class=disease_class,
-            min_dsi=min_dsi,
-            max_dsi=max_dsi,
-            min_dpi=min_dpi,
-            max_dpi=max_dpi,
-            limit=limit,
-        )
-
-    def get_gdas_by_genes(
-        self,
-        gene: Union[str, List[str]],
-        disease: Union[str, List[str]] = None,
-        source: str = None,
-        min_score: float = None,
-        max_score: float = None,
-        min_ei: float = None,
-        max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
-        min_dsi: float = None,
-        max_dsi: float = None,
-        min_dpi: float = None,
-        max_dpi: float = None,
-        min_pli: float = None,
-        max_pli: float = None,
-        limit: int = None,
-    ) -> NamedTuple(
-        "GeneDiseaseAssociation",
-        [
-            ("geneid", int),
-            ("gene_symbol", str),
-            ("uniprotid", str),
-            ("gene_dsi", float),
-            ("gene_dpi", float),
-            ("gene_pli", float),
-            ("protein_class", str),
-            ("protein_class_name", str),
-            ("diseaseid", str),
-            ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
-            ("disease_type", str),
-            ("disease_semantic_type", str),
-            ("score", float),
-            ("ei", float),
-            ("el", str),
-            ("year_initial", int),
-            ("year_final", int),
-            ("source", str),
-        ],
-    ):
-        """
-        Returns Gene-Disease Associations by gene(s).
-
-        @gene: Union[str, List[str]]
-            Gene (NCBI Entrez Identifier or HGNC Symbol) or list of genes up to 100.
-        @disease: Union[str, List[str]]
-            Disease id (UMLS CUI) or list of disease ids up to 100.
-        @source: str
-            Source of the GDA.
-            Available values : CURATED, INFERRED, ANIMAL_MODELS, ALL, BEFREE, CGI, CLINGEN,
-            CLINVAR, CTD_human, CTD_mouse, CTD_rat, GENOMICS_ENGLAND, GWASCAT, GWASDB, HPO,
-            LHGDN, MGD, ORPHANET, PSYGENET, RGD, UNIPROT
-        @min_score: float
-            Min value of the gene-disease score range.
-        @max_score: float
-            Max value of the gene-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the gene.
-        @max_dsi: float
-            Max value of the DSI range for the gene.
-        @min_dpi: float
-            Min value of the DPI range for the gene.
-        @max_dpi: float
-            Max value of the DPI range for the gene.
-        @min_pli: float
-            Min value of the pLI range.
-        @max_pli: float
-            Max value of the pLI range.
-        @limit: int
-            Number of GDAs to retrieve.
-        """
-
-        gene = self._list_to_str(gene, "Gene ID", limit=100)
-        disease = self._list_to_str(disease, "Disease ID", limit=100)
-
-        return self._get_gdas(
-            gene=gene,
-            disease=disease,
-            uniprot=None,
-            vocabulary=None,
-            by="gene",
-            source=source,
-            min_score=min_score,
-            max_score=max_score,
-            min_ei=min_ei,
-            max_ei=max_ei,
-            disease_type=disease_type,
-            disease_class=disease_class,
-            min_dsi=min_dsi,
-            max_dsi=max_dsi,
-            min_dpi=min_dpi,
-            max_dpi=max_dpi,
-            min_pli=min_pli,
-            max_pli=max_pli,
-            limit=limit,
-        )
-
-    def get_gdas_by_diseases(
-        self,
-        disease: Union[str, List[str]],
-        gene: Union[str, List[str]] = None,
-        vocabulary: str = None,
-        source: str = None,
-        min_score: float = None,
-        max_score: float = None,
-        min_ei: float = None,
-        max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
-        min_dsi: float = None,
-        max_dsi: float = None,
-        min_dpi: float = None,
-        max_dpi: float = None,
-        min_pli: float = None,
-        max_pli: float = None,
-        limit: int = None,
-    ) -> NamedTuple(
-        "GeneDiseaseAssociation",
-        [
-            ("geneid", int),
-            ("gene_symbol", str),
-            ("uniprotid", str),
-            ("gene_dsi", float),
-            ("gene_dpi", float),
-            ("gene_pli", float),
-            ("protein_class", str),
-            ("protein_class_name", str),
-            ("diseaseid", str),
-            ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
-            ("disease_type", str),
-            ("disease_semantic_type", str),
-            ("score", float),
-            ("ei", float),
-            ("el", str),
-            ("year_initial", int),
-            ("year_final", int),
-            ("source", str),
-        ],
-    ):
-        """
-        Returns Gene-Disease Associations by disease(s).
-
-        @disease: Union[str, List[str]]
-            if vocabulary is given:
-                Disease id (ICD9CM, ICD10, MeSH, OMIM, DO, EFO, NCI, HPO, MONDO,
-                or ORDO identifier) or list of disease ids up to 100.
-            else:
-                Disease id (UMLS CUI) or list of diseases up to 100.
-        @vocabulary: str
-            Disease Vocabulary.
-            Available values : icd9cm, icd10, mesh, omim, do, efo, nci, hpo, mondo, ordo
-        @gene: Union[str, List[str]]
-            Gene (NCBI Entrez Identifier or HGNC Symbol) or list of genes to filter the results.
-        @by: str
-            Return associations by:
-            Avaliable values : genes, disease, uniprot, source
-        @source: str
-            Source of the GDA.
-            Available values : CURATED, INFERRED, ANIMAL_MODELS, ALL, BEFREE, CGI, CLINGEN,
-            CLINVAR, CTD_human, CTD_mouse, CTD_rat, GENOMICS_ENGLAND, GWASCAT, GWASDB, HPO,
-            LHGDN, MGD, ORPHANET, PSYGENET, RGD, UNIPROT
-        @min_score: float
-            Min value of the gene-disease score range.
-        @max_score: float
-            Max value of the gene-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the gene.
-        @max_dsi: float
-            Max value of the DSI range for the gene.
-        @min_dpi: float
-            Min value of the DPI range for the gene.
-        @max_dpi: float
-            Max value of the DPI range for the gene.
-        @min_pli: float
-            Min value of the pLI range.
-        @max_pli: float
-            Max value of the pLI range.
-        @limit: int
-            Number of GDAs to retrieve.
-        """
-
-        gene = self._list_to_str(gene, "Gene ID")
-        disease = self._list_to_str(disease, "Disease ID", limit=100)
-
-        return self._get_gdas(
-            gene=gene,
-            disease=disease,
-            uniprot=None,
-            vocabulary=vocabulary,
-            by="disease",
-            source=source,
-            min_score=min_score,
-            max_score=max_score,
-            min_ei=min_ei,
-            max_ei=max_ei,
-            disease_type=disease_type,
-            disease_class=disease_class,
-            min_dsi=min_dsi,
-            max_dsi=max_dsi,
-            min_dpi=min_dpi,
-            max_dpi=max_dpi,
-            min_pli=min_pli,
-            max_pli=max_pli,
-            limit=limit,
-        )
-
-    def get_gdas_by_uniprots(
-        self,
-        uniprot: Union[str, List[str]],
-        disease: Union[str, List[str]] = None,
-        source: str = None,
-        min_score: float = None,
-        max_score: float = None,
-        min_ei: float = None,
-        max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
-        min_dsi: float = None,
-        max_dsi: float = None,
-        min_dpi: float = None,
-        max_dpi: float = None,
-        min_pli: float = None,
-        max_pli: float = None,
-        limit: int = None,
-    ) -> NamedTuple(
-        "GeneDiseaseAssociation",
-        [
-            ("geneid", int),
-            ("gene_symbol", str),
-            ("uniprotid", str),
-            ("gene_dsi", float),
-            ("gene_dpi", float),
-            ("gene_pli", float),
-            ("protein_class", str),
-            ("protein_class_name", str),
-            ("diseaseid", str),
-            ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
-            ("disease_type", str),
-            ("disease_semantic_type", str),
-            ("score", float),
-            ("ei", float),
-            ("el", str),
-            ("year_initial", int),
-            ("year_final", int),
-            ("source", str),
-        ],
-    ):
-        """
-        Returns Gene-Disease Associations by UniProt Accession(s).
-
-        @uniprot: Union[str, List[str]]
-            UniProt identifier or list of UniProt identifiers up to 100.
-        @disease: Union[str, List[str]]
-            Disease id (UMLS CUI) or list of diseases to filter the results.
-        @source: str
-            Source of the GDA.
-            Available values : CURATED, INFERRED, ANIMAL_MODELS, ALL, BEFREE, CGI, CLINGEN,
-            CLINVAR, CTD_human, CTD_mouse, CTD_rat, GENOMICS_ENGLAND, GWASCAT, GWASDB, HPO,
-            LHGDN, MGD, ORPHANET, PSYGENET, RGD, UNIPROT
-        @min_score: float
-            Min value of the gene-disease score range.
-        @max_score: float
-            Max value of the gene-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the gene.
-        @max_dsi: float
-            Max value of the DSI range for the gene.
-        @min_dpi: float
-            Min value of the DPI range for the gene.
-        @max_dpi: float
-            Max value of the DPI range for the gene.
-        @min_pli: float
-            Min value of the pLI range.
-        @max_pli: float
-            Max value of the pLI range.
-        @limit: int
-            Number of GDAs to retrieve.
-        """
-
-        uniprot = self._list_to_str(uniprot, "Uniprot ID", limit=100)
-        disease = self._list_to_str(disease, "Disease ID")
-
-        return self._get_gdas(
-            gene=None,
-            disease=disease,
-            uniprot=uniprot,
-            vocabulary=None,
-            by="uniprot",
-            source=source,
-            min_score=min_score,
-            max_score=max_score,
-            min_ei=min_ei,
-            max_ei=max_ei,
-            disease_type=disease_type,
-            disease_class=disease_class,
-            min_dsi=min_dsi,
-            max_dsi=max_dsi,
-            min_dpi=min_dpi,
-            max_dpi=max_dpi,
-            min_pli=min_pli,
-            max_pli=max_pli,
-            limit=limit,
-        )
-
-    def get_gdas_by_source(
-        self,
-        source: str,
-        gene: Union[str, List[str]] = None,
-        disease: Union[str, List[str]] = None,
-        min_score: float = None,
-        max_score: float = None,
-        min_ei: float = None,
-        max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
-        min_dsi: float = None,
-        max_dsi: float = None,
-        min_dpi: float = None,
-        max_dpi: float = None,
-        min_pli: float = None,
-        max_pli: float = None,
-        limit: int = None,
-    ) -> NamedTuple(
-        "GeneDiseaseAssociation",
-        [
-            ("geneid", int),
-            ("gene_symbol", str),
-            ("uniprotid", str),
-            ("gene_dsi", float),
-            ("gene_dpi", float),
-            ("gene_pli", float),
-            ("protein_class", str),
-            ("protein_class_name", str),
-            ("diseaseid", str),
-            ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
-            ("disease_type", str),
-            ("disease_semantic_type", str),
-            ("score", float),
-            ("ei", float),
-            ("el", str),
-            ("year_initial", int),
-            ("year_final", int),
-            ("source", str),
-        ],
-    ):
-        """
-        Returns Gene-Disease Associations by source.
-
-        @source: str
-            Source of the GDA.
-            Available values : CURATED, INFERRED, ANIMAL_MODELS, ALL, BEFREE, CGI, CLINGEN,
-            CLINVAR, CTD_human, CTD_mouse, CTD_rat, GENOMICS_ENGLAND, GWASCAT, GWASDB, HPO,
-            LHGDN, MGD, ORPHANET, PSYGENET, RGD, UNIPROT
-        @gene: Union[str, List[str]]
-            Gene (NCBI Entrez Identifier or HGNC Symbol) or list of genes to filter the results.
-        @disease: Union[str, List[str]]
-            Disease id (UMLS CUI) or list of diseases to filter the results.
-        @min_score: float
-            Min value of the gene-disease score range.
-        @max_score: float
-            Max value of the gene-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the gene.
-        @max_dsi: float
-            Max value of the DSI range for the gene.
-        @min_dpi: float
-            Min value of the DPI range for the gene.
-        @max_dpi: float
-            Max value of the DPI range for the gene.
-        @min_pli: float
-            Min value of the pLI range.
-        @max_pli: float
-            Max value of the pLI range.
-        @limit: int
-            Number of GDAs to retrieve.
-        """
-
-        gene = self._list_to_str(gene, "Gene ID")
-        disease = self._list_to_str(disease, "Disease ID")
-
-        return self._get_gdas(
-            gene=gene,
-            disease=disease,
-            uniprot=None,
-            vocabulary=None,
-            by="source",
-            source=source,
-            min_score=min_score,
-            max_score=max_score,
-            min_ei=min_ei,
-            max_ei=max_ei,
-            disease_type=disease_type,
-            disease_class=disease_class,
-            min_dsi=min_dsi,
-            max_dsi=max_dsi,
-            min_dpi=min_dpi,
-            max_dpi=max_dpi,
-            min_pli=min_pli,
-            max_pli=max_pli,
-            limit=limit,
-        )
-        
-    def get_vda_evidences_by_variant(
-        variant,
-        gene=None,
-        disease=None,
-        source: str = None,
-        min_year: int = None,
-        max_year: int = None,
-        min_score: float = None,
-        max_score: float = None,
-        limit: int = None,
-        offset: int = None,
-        get_all: bool = True
-    ):
-        
-        variant = self._list_to_str(variant, "variant ID", limit=100)
-        
-        if disease != None:
-            disease = self._list_to_str(disease, "disease ID", limit=100)
-        
-        if gene != None:
-            gene = self._list_to_str(gene, "gene ID")
-        
-        return _get_evidences(
-            of="vda",
-            by="variant",
-            gene = gene,
-            disease = disease,
-            variant = variant,
-            source = source,
-            min_year = min_year,
-            max_year = max_year,
-            min_score = min_score,
-            max_score = max_score,
-            limit = limit,
-            offset = offset,
-            get_all = get_all
-        )
     
-    def get_vda_evidences_by_disease(
-        disease,
-        variant=None,
-        gene=None,
-        source: str = None,
-        min_year: int = None,
-        max_year: int = None,
-        min_score: float = None,
-        max_score: float = None,
-        limit: int = None,
-        offset: int = None,
-        get_all: bool = True
-    ):
-        
-        disease = self._list_to_str(disease, "disease ID", limit=100)
-        
+    # _get_vdas(), get_vdas_by_variants(), get_vdas_by_genes(),
+    # get_vdas_by_diseases(), and get_vdas_by_source() were removed. These
+    # five functions existed to select a "by" routing mode (gene, disease,
+    # variant, source) for the old path-based /vda/{by}/... endpoint,
+    # where each identifier type required a different URL. The new API
+    # has a single fixed endpoint (/vda/summary) where variant, gene,
+    # disease, source, etc. are all just optional query parameters on the
+    # same call, so there's no more separate URL/routing per identifier
+    # type. Replaced by the single get_vda_summary() function below, which
+    # accepts all identifier types and filters at once.
+
+    def get_vda_summary(
+    self,
+    variant: Union[str, List[str]] = None,
+    gene_ncbi_id: Union[str, List[str]] = None,
+    gene_symbol: Union[str, List[str]] = None,
+    disease: Union[str, List[str]] = None,
+    source: Union[str, List[str]] = None,
+    min_score: float = None,
+    max_score: float = None,
+    min_ei: float = None,
+    max_ei: float = None,
+    min_dsi: float = None,
+    max_dsi: float = None,
+    min_dpi: float = None,
+    max_dpi: float = None,
+    dis_class_list: Union[str, List[str]] = None,
+    page_number: int = None,
+) -> NamedTuple(
+    "VariantDiseaseAssociation",
+    [
+        ("variantid", str),
+        ("gene_symbol", Tuple[str]),
+        ("variant_dsi", float),
+        ("variant_dpi", float),
+        ("variant_consequence_type", str),
+        ("diseaseid", str),
+        ("disease_name", str),
+        ("disease_classes_do", Tuple[str]),
+        ("disease_classes_hpo", Tuple[str]),
+        ("disease_classes_msh", Tuple[str]),
+        ("disease_classes_umls_st", Tuple[str]),
+        ("disease_type", str),
+        ("score", float),
+        ("ei", float),
+        ("year_initial", int),
+        ("year_final", int),
+        ("source", str),
+    ],
+):
+        """
+        Returns Variant-Disease Associations (aggregated summary), narrowed
+        to the fields the old get_vdas_by_variants/genes/diseases/source()
+        functions returned.
+
+        disease_type is now populated from the API's "diseaseType" field.
+        It was previously hardcoded to None based on an incorrect reading
+        of the response schema; confirmed via real test data (e.g.
+        disease_type='phenotype' for a real query) that this field is
+        actually present in /vda/summary's response.
+
+        disease_class_name is not included: same situation as in
+        get_dda/get_gda_summary - the old API had a separate class-name
+        field, the new API only returns the combined "name (code)" string
+        in disease_class.
+
+        @variant: Union[str, List[str]]
+            Variant (dbSNP Identifier) or list of variants, up to 100.
+        @gene_ncbi_id / @gene_symbol: Union[str, List[str]]
+            Gene identifier(s); the old "gene" param accepted either NCBI
+            ID or HGNC symbol, the new API splits these into two params.
+        @disease: Union[str, List[str]]
+            Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
+        @source: Union[str, List[str]]
+            Source of the VDA.
+        @min_score/@max_score, @min_ei/@max_ei, @min_dsi/@max_dsi,
+        @min_dpi/@max_dpi: float
+            Score ranges, in [0,1].
+        @dis_class_list: Union[str, List[str]]
+            MeSH Disease Classes - corresponds to the old "disease_class"
+            param.
+        @page_number: int
+            Page number - corresponds to the old "limit" param (100 per
+            page; TRIAL accounts are capped at the top-30 results and do
+            not support pagination).
+        """
+
+        url = f"{self._api_url}/vda/summary"
+        get_params = dict()
+
         if variant != None:
-            variant = self._list_to_str(variant, "variant ID", limit=100)
-        
-        if gene != None:
-            gene = self._list_to_str(gene, "gene ID")
-        
-        return _get_evidences(
-            of="vda",
-            by="disease",
-            gene = gene,
-            disease = disease,
-            variant = variant,
-            source = source,
-            min_year = min_year,
-            max_year = max_year,
-            min_score = min_score,
-            max_score = max_score,
-            limit = limit,
-            offset = offset,
-            get_all = get_all
-        )
-    
-    def get_gda_evidences_by_gene(
-        gene,
-        disease=None,
-        source: str = None,
-        min_year: int = None,
-        max_year: int = None,
-        min_score: float = None,
-        max_score: float = None,
-        limit: int = None,
-        offset: int = None,
-        get_all: bool = True
-    ):
-        
-        gene = self._list_to_str(gene, "gene ID", limit=100)
-        
+            get_params["variant"] = self._list_to_str(variant, "Variant ID", limit=100)
+
+        if gene_ncbi_id != None:
+            get_params["gene_ncbi_id"] = self._list_to_str(gene_ncbi_id, "Gene NCBI ID", limit=100)
+
+        if gene_symbol != None:
+            get_params["gene_symbol"] = self._list_to_str(gene_symbol, "Gene Symbol", limit=100)
+
         if disease != None:
-            disease = self._list_to_str(disease, "disease ID", limit=100)
-        
-        return _get_evidences(
-            of="gda",
-            by="gene",
-            gene = gene,
-            disease = disease,
-            variant = None,
-            source = source,
-            min_year = min_year,
-            max_year = max_year,
-            min_score = min_score,
-            max_score = max_score,
-            limit = limit,
-            offset = offset,
-            get_all = get_all
-        )
-    
-    def get_gda_evidences_by_disease(
-        disease,
-        gene=None,
-        source: str = None,
-        min_year: int = None,
-        max_year: int = None,
-        min_score: float = None,
-        max_score: float = None,
-        limit: int = None,
-        offset: int = None,
-        get_all: bool = True
-    ):
-        
-        disease = self._list_to_str(disease, "disease ID", limit=100)
-        
-        if gene != None:
-            gene = self._list_to_str(gene, "gene ID", limit=100)
-        
-        return _get_evidences(
-            of="vda",
-            by="disease",
-            gene = gene,
-            disease = disease,
-            variant = None,
-            source = source,
-            min_year = min_year,
-            max_year = max_year,
-            min_score = min_score,
-            max_score = max_score,
-            limit = limit,
-            offset = offset,
-            get_all = get_all
-        )
-
-    def _get_ddas(
-        self,
-        disease: Union[str, List[str]],
-        share: str = None,
-        vocabulary: str = None,
-        source: str = None,
-        p_value: float = None,
-        limit: int = 10,
-    ) -> NamedTuple(
-        "DiseaseDiseaseAssociation",
-        [
-            ("disease1_name", str),
-            ("disease2_name", str),
-            ("disease1_nshare", int),
-            ("disease2_nshare", int),
-            ("disease1_disease_class", Tuple[str]),
-            ("disease2_disease_class", Tuple[str]),
-            ("disease1_disease_class_name", Tuple[str]),
-            ("disease2_disease_class_name", Tuple[str]),
-            ("jaccard_share", float),
-            ("pvalue_jaccard_share", float),
-            ("source", str),
-            ("ngenes1", int),
-            ("ngenes2", int),
-            ("nshare", int),
-            ("nvariants1", int),
-            ("nvariants2", int),
-            ("diseaseid1", str),
-            ("diseaseid2", str),
-        ],
-    ):
-        """
-        Returns Disease-Disease Associations with given query.
-
-        @disease: Union[str, List[str]]
-            if vocabulary is given:
-                Disease id (ICD9CM, ICD10,MeSH, OMIM, DO, EFO,
-                NCI, HPO, MONDO, or ORDO identifier) or list of disease ids
-            else:
-                Disease id (UMLS CUI) or list of disease ids
-        @share: str
-            Return associations that share:
-            Avaliable values : genes, variants
-        @vocabulary: str
-            Disease Vocabulary.
-            Available values : icd9cm, icd10, mesh, omim, do, efo,
-            nci, hpo, mondo, ordo
-        @source: str
-            Source of the DDA.
-            Available values : CURATED, INFERRED, ANIMAL_MODELS, ALL, BEFREE,
-            CGI, CLINGEN, CLINVAR, CTD_human, CTD_mouse, CTD_rat, GENOMICS_ENGLAND,
-            GWASCAT, GWASDB, HPO, LHGDN, MGD, ORPHANET, PSYGENET, RGD, UNIPROT
-        @p_value: float
-            p value associated to the Jaccard Index based on the shared genes.
-        @limit: int
-            Number of associated diseases to retrieve.
-            Default value : 10
-        """
-
-        disease = self._list_to_str(disease, "disease ID", limit=100)
-
-        url = f"{self._api_url}/dda/{share}/disease/"
-
-        if vocabulary != None:
-            url += f"{vocabulary}/"
-
-        url += disease
-        get_params = dict()
-        # headers = dict()
-
-        if source != None:
-            get_params["source"] = source
-
-        if p_value != None:
-            get_params["pvalue"] = str(p_value)
-
-        get_params["limit"] = str(max(1, min(limit, 100)))
-
-        result = self._retrieve_data(url, get_params)
-
-        if result == None:
-            return None
-
-        DiseaseDiseaseAssociation = collections.namedtuple(
-            "DiseaseDiseaseAssociation",
-            [
-                "disease1_name",
-                "disease2_name",
-                f"disease1_n{share}",
-                f"disease2_n{share}",
-                "disease1_disease_class",
-                "disease2_disease_class",
-                "disease1_disease_class_name",
-                "disease2_disease_class_name",
-                f"jaccard_{share}",
-                f"pvalue_jaccard_{share}",
-                "source",
-                "ngenes1",
-                "ngenes2",
-                f"n{share}",
-                "nvariants1",
-                "nvariants2",
-                "diseaseid1",
-                "diseaseid2",
-            ],
-        )
-
-        for index, entry in enumerate(result):
-            result[index] = DiseaseDiseaseAssociation(
-                self._get_string(entry["disease1_name"]),
-                self._get_string(entry["disease2_name"]),
-                self._get_int(entry[f"disease1_n{share}"]),
-                self._get_int(entry[f"disease2_n{share}"]),
-                self._get_tuple(entry["disease1_disease_class"], ";"),
-                self._get_tuple(entry["disease2_disease_class"], ";"),
-                self._get_tuple(entry["disease1_disease_class_name"], ";"),
-                self._get_tuple(entry["disease2_disease_class_name"], ";"),
-                self._get_float(entry[f"jaccard_{share}"]),
-                self._get_float(entry[f"pvalue_jaccard_{share}"]),
-                self._get_string(entry["source"]),
-                self._get_int(entry["ngenes1"]),
-                self._get_int(entry["ngenes2"]),
-                self._get_int(entry[f"n{share}"]),
-                self._get_int(entry["nvariants1"]),
-                self._get_int(entry["nvariants2"]),
-                self._get_string(entry["diseaseid1"]),
-                self._get_string(entry["diseaseid2"]),
-            )
-
-        return result
-
-    def _get_vdas(
-        self,
-        gene: Union[str, List[str]] = None,
-        disease: Union[str, List[str]] = None,
-        variant: Union[str, List[str]] = None,
-        vocabulary: str = None,
-        by: str = None,
-        source: str = None,
-        min_score: float = None,
-        max_score: float = None,
-        min_ei: float = None,
-        max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
-        min_dsi: float = None,
-        max_dsi: float = None,
-        min_dpi: float = None,
-        max_dpi: float = None,
-        limit: int = None,
-    ) -> NamedTuple(
-        "VariantDiseaseAssociation",
-        [
-            ("variantid", str),
-            ("gene_symbol", str),
-            ("variant_dsi", float),
-            ("variant_dpi", float),
-            ("variant_consequence_type", str),
-            ("diseaseid", str),
-            ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
-            ("disease_type", str),
-            ("disease_semantic_type", str),
-            ("score", float),
-            ("ei", float),
-            ("year_initial", int),
-            ("year_final", int),
-            ("source", str),
-        ],
-    ):
-        """
-        Returns Variant-Disease Associations with given query.
-
-        @gene: Union[str, List[str]]
-            Gene (NCBI Entrez Identifier or HGNC Symbol) or list of genes.
-        @disease: Union[str, List[str]]
-            if vocabulary is given:
-                Disease id (ICD9CM, ICD10, MeSH, OMIM, DO, EFO, NCI, HPO, MONDO,
-                or ORDO identifier) or list of disease ids.
-            else:
-                Disease id (UMLS CUI) or list of diseases.
-        @variant: Union[str, List[str]]
-            Variant (dbSNP Identifier) or list of variants.
-        @vocabulary: str
-            Disease Vocabulary.
-            Available values : icd9cm, icd10, mesh, omim, do, efo, nci, hpo, mondo, ordo
-        @by: str
-            Return associations by:
-            Avaliable values : gene, disease, variant, source
-        @source: str
-            Source of the VDA.
-            Available values : CURATED, BEFREE, ALL, CLINVAR, GWASCAT, GWASDB, UNIPROT
-        @min_score: float
-            Min value of the variant-disease score range.
-        @max_score: float
-            Max value of the variant-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the variant.
-        @max_dsi: float
-            Max value of the DSI range for the variant.
-        @min_dpi: float
-            Min value of the DPI range for the variant.
-        @max_dpi: float
-            Max value of the DPI range for the variant.
-        @limit: int
-            Number of VDAs to retrieve.
-        """
-
-        url = f"{self._api_url}/vda/"
-        get_params = dict()
-
-        if by == "gene" and gene != None:
-            url += f"gene/{gene}"
-
-            if disease != None:
-                get_params["disease"] = disease
-
-            if variant != None:
-                get_params["variant"] = variant
-
-        elif by == "disease" and disease != None:
-            if vocabulary != None:
-                url += f"disease/{vocabulary}/{disease}"
-
-            else:
-                url += f"disease/{disease}"
-
-            if gene != None:
-                get_params["gene"] = gene
-
-            if variant != None:
-                get_params["variant"] = variant
-
-        elif by == "variant" and variant != None:
-            url += f"variant/{variant}"
-
-            if disease != None:
-                get_params["disease"] = disease
-
-            if gene != None:
-                get_params["gene"] = gene
-
-        elif by == "source":
-            url += f"source/{source}"
-
-            if disease != None:
-                get_params["disease"] = disease
-
-            if variant != None:
-                get_params["variant"] = variant
-
-            if gene != None:
-                get_params["gene"] = gene
-        else:
-            print("Problem in function call. Check arguments.")
-
-            return None
+            get_params["disease"] = self._list_to_str(disease, "Disease ID", limit=100)
 
         if source != None:
             get_params["source"] = source
@@ -1554,15 +222,6 @@ class DisgenetApi:
         if max_ei != None:
             get_params["max_ei"] = str(max_ei)
 
-        if min_score != None:
-            get_params["min_score"] = str(min_score)
-
-        if disease_type != None:
-            get_params["type"] = disease_type
-
-        if disease_class != None:
-            get_params["disease_class"] = disease_class
-
         if min_dsi != None:
             get_params["min_dsi"] = str(min_dsi)
 
@@ -1575,8 +234,11 @@ class DisgenetApi:
         if max_dpi != None:
             get_params["max_dpi"] = str(max_dpi)
 
-        if limit != None:
-            get_params["limit"] = str(max(1, limit))
+        if dis_class_list != None:
+            get_params["dis_class_list"] = dis_class_list
+
+        if page_number != None:
+            get_params["page_number"] = str(page_number)
 
         result = self._retrieve_data(url, get_params)
 
@@ -1593,10 +255,11 @@ class DisgenetApi:
                 "variant_consequence_type",
                 "diseaseid",
                 "disease_name",
-                "disease_class",
-                "disease_class_name",
+                "disease_classes_do",
+                "disease_classes_hpo",
+                "disease_classes_msh",
+                "disease_classes_umls_st",
                 "disease_type",
-                "disease_semantic_type",
                 "score",
                 "ei",
                 "year_initial",
@@ -1607,64 +270,78 @@ class DisgenetApi:
 
         for index, entry in enumerate(result):
             result[index] = VariantDiseaseAssociation(
-                self._get_string(entry["variantid"]),
-                self._get_string(entry["gene_symbol"]),
-                self._get_float(entry["variant_dsi"]),
-                self._get_float(entry["variant_dpi"]),
-                self._get_string(entry["variant_consequence_type"]),
-                self._get_string(entry["diseaseid"]),
-                self._get_string(entry["disease_name"]),
-                self._get_tuple(entry["disease_class"], ";"),
-                self._get_tuple(entry["disease_class_name"], ";"),
-                self._get_string(entry["disease_type"]),
-                self._get_string(entry["disease_semantic_type"]),
-                self._get_float(entry["score"]),
-                self._get_float(entry["ei"]),
-                self._get_int(entry["year_initial"]),
-                self._get_int(entry["year_final"]),
-                self._get_string(entry["source"]),
+                self._get_string(entry.get("variantStrID")),
+                tuple(entry["geneSymbol_keyword"]) if entry.get("geneSymbol_keyword") else None,
+                self._get_float(entry.get("variantDSI")),
+                self._get_float(entry.get("variantDPI")),
+                self._get_string(entry.get("mostSevereConsequences")),
+                self._get_string(entry.get("diseaseUMLSCUI")),
+                self._get_string(entry.get("diseaseName")),
+                tuple(entry["diseaseClasses_DO"]) if entry.get("diseaseClasses_DO") else None,
+                tuple(entry["diseaseClasses_HPO"]) if entry.get("diseaseClasses_HPO") else None, # Likely None for most records, but keeping the field since it may be populated depending on the variant/gene - didn't want to silently drop this classification data.
+                tuple(entry["diseaseClasses_MSH"]) if entry.get("diseaseClasses_MSH") else None,
+                tuple(entry["diseaseClasses_UMLS_ST"]) if entry.get("diseaseClasses_UMLS_ST") else None,
+                self._get_string(entry.get("diseaseType")),
+                self._get_float(entry.get("score")),
+                self._get_float(entry.get("ei")),
+                self._get_int(entry.get("yearInitial")),
+                self._get_int(entry.get("yearFinal")),
+                self._get_string(entry.get("source")),
             )
 
         return result
 
-    def _get_gdas(
+    
+    # get_gdas_by_genes(), get_gdas_by_diseases(), get_gdas_by_uniprots(),
+    # get_gdas_by_source(), and _get_gdas() were removed. These functions
+    # existed to select a "by" routing mode (gene, disease, uniprot,
+    # source) for the old path-based /gda/{by}/... endpoint, where each
+    # identifier type required a different URL. The new API has a single
+    # fixed endpoint (/gda/summary) where gene, disease, uniprot, source,
+    # etc. are all just optional query parameters on the same call, so
+    # there's no more separate URL/routing per identifier type. Replaced
+    # by the single get_gda_summary() function below, which accepts all
+    # identifier types and filters at once. This mirrors the same removal
+    # already done for the VDA summary functions (get_vdas_by_*/_get_vdas).
+    def get_gda_summary(
         self,
-        gene: Union[str, List[str]] = None,
+        gene_ncbi_id: Union[str, List[str]] = None,
+        gene_ensembl_id: Union[str, List[str]] = None,
+        gene_symbol: Union[str, List[str]] = None,
+        uniprot_id: Union[str, List[str]] = None,
         disease: Union[str, List[str]] = None,
-        uniprot: Union[str, List[str]] = None,
-        vocabulary: str = None,
-        by: str = None,
-        source: str = None,
+        source: Union[str, List[str]] = None,
         min_score: float = None,
         max_score: float = None,
         min_ei: float = None,
         max_ei: float = None,
-        disease_type: str = None,
-        disease_class: Union[str, List[str]] = None,
         min_dsi: float = None,
         max_dsi: float = None,
         min_dpi: float = None,
         max_dpi: float = None,
         min_pli: float = None,
         max_pli: float = None,
-        limit: int = None,
+        type: str = None,
+        dis_class_list: Union[str, List[str]] = None,
+        page_number: int = None,
     ) -> NamedTuple(
         "GeneDiseaseAssociation",
         [
             ("geneid", int),
             ("gene_symbol", str),
-            ("uniprotid", str),
+            ("uniprotid", Tuple[str]),
             ("gene_dsi", float),
             ("gene_dpi", float),
             ("gene_pli", float),
-            ("protein_class", str),
-            ("protein_class_name", str),
+            ("protein_class", Tuple[str]),
+            ("protein_class_name", Tuple[str]),
             ("diseaseid", str),
             ("disease_name", str),
-            ("disease_class", Tuple[str]),
-            ("disease_class_name", Tuple[str]),
+            ("disease_classes_do", Tuple[str]),
+            ("disease_classes_hpo", Tuple[str]),
+            ("disease_classes_msh", Tuple[str]),
+            ("disease_classes_umls_st", Tuple[str]),
             ("disease_type", str),
-            ("disease_semantic_type", str),
             ("score", float),
             ("ei", float),
             ("el", str),
@@ -1674,101 +351,51 @@ class DisgenetApi:
         ],
     ):
         """
-        Returns Gene-Disease Associations with given query.
+        Returns Gene-Disease Associations (aggregated summary), narrowed
+        to the fields the old get_gdas_by_genes/diseases/uniprots/source()
+        functions returned.
 
-        @gene: Union[str, List[str]]
-            Gene (NCBI Entrez Identifier or HGNC Symbol) or list of genes.
+        @gene_ncbi_id / @gene_ensembl_id / @gene_symbol: Union[str, List[str]]
+            Gene identifier(s) in the respective vocabulary, up to 100.
+        @uniprot_id: Union[str, List[str]]
+            Uniprot accession(s), up to 100.
         @disease: Union[str, List[str]]
-            if vocabulary is given:
-                Disease id (ICD9CM, ICD10, MeSH, OMIM, DO, EFO, NCI, HPO, MONDO,
-                or ORDO identifier) or list of disease ids.
-            else:
-                Disease id (UMLS CUI) or list of diseases.
-        @uniprot: Union[str, List[str]]
-            Disease id (UMLS CUI) or list of disease ids.
-        @vocabulary: str
-            Disease Vocabulary.
-            Available values : icd9cm, icd10, mesh, omim, do, efo, nci, hpo, mondo, ordo
-        @by: str
-            Return associations by:
-            Avaliable values : gene, disease, uniprot, source
-        @source: str
+            Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
+        @source: Union[str, List[str]]
             Source of the GDA.
-            Available values : CURATED, INFERRED, ANIMAL_MODELS, ALL, BEFREE, CGI, CLINGEN,
-            CLINVAR, CTD_human, CTD_mouse, CTD_rat, GENOMICS_ENGLAND, GWASCAT, GWASDB, HPO,
-            LHGDN, MGD, ORPHANET, PSYGENET, RGD, UNIPROT
-        @min_score: float
-            Min value of the gene-disease score range.
-        @max_score: float
-            Max value of the gene-disease score range.
-        @min_ei: float
-            Min value of the evidence index range.
-        @max_ei: float
-            Max value of the evidence index range.
-        @disease_type: str
-            DisGeNET Disease Type.
-            Available values : disease, phenotype, group
-        @disease_class: Union[str, List[str]]
-            MeSH Disease Classes
-            Available values : C01, C04, C05, C06, C07, C08, C09, C10, C11, C12,
-            C13, C14, C15, C16, C17, C18, C19, C20, C21, C22, C23, C24, C25, C26,
-            F01, F02, F03
-        @min_dsi: float
-            Min value of the DSI range for the gene.
-        @max_dsi: float
-            Max value of the DSI range for the gene.
-        @min_dpi: float
-            Min value of the DPI range for the gene.
-        @max_dpi: float
-            Max value of the DPI range for the gene.
-        @min_pli: float
-            Min value of the pLI range.
-        @max_pli: float
-            Max value of the pLI range.
-        @limit: int
-            Number of GDAs to retrieve.
+        @min_score/@max_score, @min_ei/@max_ei, @min_dsi/@max_dsi,
+        @min_dpi/@max_dpi, @min_pli/@max_pli: float
+            Score ranges, in [0,1].
+        @type: str
+            DisGeNET Disease Type ("disease", "phenotype", "group").
+        @dis_class_list: Union[str, List[str]]
+            MeSH Disease Classes - corresponds to the old "disease_class"
+            param.
+        @page_number: int
+            Page number - corresponds to the old "limit" param (100 per
+            page; TRIAL accounts are capped at the top-30 results and do
+            not support pagination).
         """
-        
-        url = f"{self._api_url}/gda/"
+
+        url = f"{self._api_url}/gda/summary"
         get_params = dict()
 
-        if by == "gene" and gene != None:
-            url += f"gene/{gene}"
+        if gene_ncbi_id != None:
+            get_params["gene_ncbi_id"] = self._list_to_str(gene_ncbi_id, "Gene NCBI ID", limit=100)
 
-            if disease != None:
-                get_params["disease"] = disease
+        if gene_ensembl_id != None:
+            get_params["gene_ensembl_id"] = self._list_to_str(gene_ensembl_id, "Gene Ensembl ID", limit=100)
 
-        elif by == "disease" and disease != None:
-            if vocabulary != None:
-                url += f"disease/{vocabulary}/{disease}"
+        if gene_symbol != None:
+            get_params["gene_symbol"] = self._list_to_str(gene_symbol, "Gene Symbol", limit=100)
 
-            else:
-                url += f"disease/{disease}"
+        if uniprot_id != None:
+            get_params["uniprot_id"] = self._list_to_str(uniprot_id, "Uniprot ID", limit=100)
 
-            if gene != None:
-                get_params["gene"] = gene
+        if disease != None:
+            get_params["disease"] = self._list_to_str(disease, "Disease ID", limit=100)
 
-        elif by == "uniprot" and uniprot != None:
-            url += f"gene/uniprot/{uniprot}"
-
-            if disease != None:
-                get_params["disease"] = disease
-
-        elif by == "source" and source != None:
-            url += f"source/{source}"
-
-            if gene != None:
-                get_params["gene"] = gene
-
-            if disease != None:
-                get_params["disease"] = disease
-
-        else:
-            print("Problem in function call. Check arguments.")
-
-            return None
-
-        if by != "source" and source != None:
+        if source != None:
             get_params["source"] = source
 
         if min_score != None:
@@ -1782,15 +409,6 @@ class DisgenetApi:
 
         if max_ei != None:
             get_params["max_ei"] = str(max_ei)
-
-        if min_score != None:
-            get_params["min_score"] = str(min_score)
-
-        if disease_type != None:
-            get_params["type"] = disease_type
-
-        if disease_class != None:
-            get_params["disease_class"] = disease_class
 
         if min_dsi != None:
             get_params["min_dsi"] = str(min_dsi)
@@ -1810,9 +428,15 @@ class DisgenetApi:
         if max_pli != None:
             get_params["max_pli"] = str(max_pli)
 
-        if limit != None:
-            get_params["limit"] = str(max(1, limit))
-        
+        if type != None:
+            get_params["type"] = type
+
+        if dis_class_list != None:
+            get_params["dis_class_list"] = dis_class_list
+
+        if page_number != None:
+            get_params["page_number"] = str(page_number)
+
         result = self._retrieve_data(url, get_params)
 
         if result == None:
@@ -1831,10 +455,11 @@ class DisgenetApi:
                 "protein_class_name",
                 "diseaseid",
                 "disease_name",
-                "disease_class",
-                "disease_class_name",
+                "disease_classes_do",
+                "disease_classes_hpo",
+                "disease_classes_msh",
+                "disease_classes_umls_st",
                 "disease_type",
-                "disease_semantic_type",
                 "score",
                 "ei",
                 "el",
@@ -1846,85 +471,109 @@ class DisgenetApi:
 
         for index, entry in enumerate(result):
             result[index] = GeneDiseaseAssociation(
-                self._get_int(entry["geneid"]),
-                self._get_string(entry["gene_symbol"]),
-                self._get_string(entry["uniprotid"]),
-                self._get_float(entry["gene_dsi"]),
-                self._get_float(entry["gene_dpi"]),
-                self._get_float(entry["gene_pli"]),
-                self._get_string(entry["protein_class"]),
-                self._get_string(entry["protein_class_name"]),
-                self._get_string(entry["diseaseid"]),
-                self._get_string(entry["disease_name"]),
-                self._get_tuple(entry["disease_class"], ";"),
-                self._get_tuple(entry["disease_class_name"], ";"),
-                self._get_string(entry["disease_type"]),
-                self._get_string(entry["disease_semantic_type"]),
-                self._get_float(entry["score"]),
-                self._get_float(entry["ei"]),
-                self._get_string(entry["el"]),
-                self._get_int(entry["year_initial"]),
-                self._get_int(entry["year_final"]),
-                self._get_string(entry["source"]),
+                self._get_int(entry.get("geneNcbiID")),
+                self._get_string(entry.get("symbolOfGene")),
+                tuple(entry["geneProteinStrIDs"]) if entry.get("geneProteinStrIDs") else None,
+                self._get_float(entry.get("geneDSI")),
+                self._get_float(entry.get("geneDPI")),
+                self._get_float(entry.get("genepLI")),
+                tuple(entry["geneProteinClassIDs"]) if entry.get("geneProteinClassIDs") else None,
+                tuple(entry["geneProteinClassNames"]) if entry.get("geneProteinClassNames") else None,
+                self._get_string(entry.get("diseaseUMLSCUI")),
+                self._get_string(entry.get("diseaseName")),
+                tuple(entry["diseaseClasses_DO"]) if entry.get("diseaseClasses_DO") else None,
+                tuple(entry["diseaseClasses_HPO"]) if entry.get("diseaseClasses_HPO") else None,
+                tuple(entry["diseaseClasses_MSH"]) if entry.get("diseaseClasses_MSH") else None,
+                tuple(entry["diseaseClasses_UMLS_ST"]) if entry.get("diseaseClasses_UMLS_ST") else None,
+                self._get_string(entry.get("diseaseType")),
+                self._get_float(entry.get("score")),
+                self._get_float(entry.get("ei")),
+                self._get_string(entry.get("el")),
+                self._get_int(entry.get("yearInitial")),
+                self._get_int(entry.get("yearFinal")),
+                self._get_string(entry.get("source")),
             )
 
         return result
 
-    def _get_evidences(
+    
+        
+    # get_vda_evidences_by_variant() and get_vda_evidences_by_disease() were
+    # removed. They existed only to select a "by" routing mode for the old
+    # path-based /vda/evidences/{by}/... endpoint. The new API has a single
+    # fixed endpoint (/vda/evidence). Replaced by get_vda_evidence() below,
+    # which keeps only the params the old functions/​_get_evidences() used
+    # (variant/gene/disease, source, min/max_year, min/max_score,
+    # limit/offset) rather than the full param set the new endpoint
+    # supports. Like the old code, this does not convert results into a
+    # namedtuple - it returns the raw list of record dicts as-is.
+    def get_vda_evidence(
         self,
-        of: ["gda" ,"vda"],
-        by: ["gene", "disease", "variant"],
-        gene: [str, [str]] = None,
-        disease: [str, [str]] = None,
-        variant: [str, [str]] = None,
-        source: str = None,
-        min_year: int = None,
-        max_year: int = None,
+        variant: Union[str, List[str]] = None,
+        gene_ncbi_id: Union[str, List[str]] = None,
+        gene_symbol: Union[str, List[str]] = None,
+        disease: Union[str, List[str]] = None,
+        source: Union[str, List[str]] = None,
+        min_pmYear: str = None,
+        max_pmYear: str = None,
         min_score: float = None,
         max_score: float = None,
-        limit: int = None,
-        offset: int = None,
-        get_all: bool = True
+        page_number: int = None,
     ):
-        url = f"{self._api_url}/{of}/evidences/{by}/"
+        """
+        Returns evidences that support Variant-Disease Associations.
+        Params narrowed to what the old get_vda_evidences_by_variant()/
+        get_vda_evidences_by_disease() (via _get_evidences()) used.
+
+        @variant: Union[str, List[str]]
+            Variant (dbSNP Identifier) or list of variants, up to 100.
+        @gene_ncbi_id / @gene_symbol: Union[str, List[str]]
+            Gene identifier(s); the old "gene" param accepted either.
+        @disease: Union[str, List[str]]
+            Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
+        @source: Union[str, List[str]]
+            Source of the VDA.
+        @min_pmYear/@max_pmYear: str
+            Publication year range - corresponds to the old
+            "min_year"/"max_year" params. The new API has both
+            min_timestamp/max_timestamp (evidence timestamp) and
+            min_pmYear/max_pmYear (publication year); mapped to the latter
+            as the closer match, but this is an assumption, not confirmed.
+        @min_score/@max_score: float
+            Variant-disease normalized score range, in [0,1].
+        @page_number: int
+            Page number - corresponds to the old "limit"/"offset" params.
+            The old code auto-looped through cursor-based pages
+            (data["next"]) when get_all=True; the new API paginates via
+            page_number instead of a cursor, and TRIAL accounts don't
+            support pagination at all, so the auto-loop was removed. This
+            returns a single page; call again with an incremented
+            page_number for more.
+        """
+
+        url = f"{self._api_url}/vda/evidence"
         get_params = dict()
-        
-        if of == "gda" and by == "gene" and gene != None:
-            url += gene
-            
-            if disease != None:
-                get_params["diasease"] = disease
-            
-        elif of == "vda" and by == "variant" and gene != None:
-            url += variant
-            
-            if gene != None:
-                get_params["gene"] = gene
-            
-            if disease != None:
-                get_params["disease"] = disease
-        
-        elif  by == "disease" and disease != None:
-            url += disease
-            
-            if gene != None:
-                get_params["gene"] = gene
-            
-            if of == "vda" and variant != None:
-                get_params["variant"] = variant
-        
-        else:
-            print("Problem in function call. Check arguments.")
-            return None
-        
+
+        if variant != None:
+            get_params["variant"] = self._list_to_str(variant, "Variant ID", limit=100)
+
+        if gene_ncbi_id != None:
+            get_params["gene_ncbi_id"] = self._list_to_str(gene_ncbi_id, "Gene NCBI ID", limit=100)
+
+        if gene_symbol != None:
+            get_params["gene_symbol"] = self._list_to_str(gene_symbol, "Gene Symbol", limit=100)
+
+        if disease != None:
+            get_params["disease"] = self._list_to_str(disease, "Disease ID", limit=100)
+
         if source != None:
             get_params["source"] = source
-        
-        if min_year != None:
-            get_params["min_year"] = str(min_year)
 
-        if max_year != None:
-            get_params["max_year"] = str(max_year)
+        if min_pmYear != None:
+            get_params["min_pmYear"] = min_pmYear
+
+        if max_pmYear != None:
+            get_params["max_pmYear"] = max_pmYear
 
         if min_score != None:
             get_params["min_score"] = str(min_score)
@@ -1932,23 +581,238 @@ class DisgenetApi:
         if max_score != None:
             get_params["max_score"] = str(max_score)
 
-        if limit != None:
-            get_params["limit"] = str(max(1, limit))
+        if page_number != None:
+            get_params["page_number"] = str(page_number)
+
+        return self._retrieve_data(url, get_params)
+
+
+    # get_gda_evidences_by_gene() and get_gda_evidences_by_disease() were
+    # removed, for the same reason as the VDA evidence functions above.
+    # Replaced by get_gda_evidence() below, same narrowed-param approach,
+    # same raw-passthrough (no namedtuple) behavior as the old code.
+    def get_gda_evidence(
+        self,
+        gene_ncbi_id: Union[str, List[str]] = None,
+        gene_symbol: Union[str, List[str]] = None,
+        disease: Union[str, List[str]] = None,
+        source: Union[str, List[str]] = None,
+        min_pmYear: str = None,
+        max_pmYear: str = None,
+        min_score: float = None,
+        max_score: float = None,
+        page_number: int = None,
+    ):
+        """
+        Returns evidences that support Gene-Disease Associations.
+        Params narrowed to what the old get_gda_evidences_by_gene()/
+        get_gda_evidences_by_disease() (via _get_evidences()) used.
+
+        @gene_ncbi_id / @gene_symbol: Union[str, List[str]]
+            Gene identifier(s); the old "gene" param accepted either.
+        @disease: Union[str, List[str]]
+            Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
+        @source: Union[str, List[str]]
+            Source of the GDA.
+        @min_pmYear/@max_pmYear: str
+            Publication year range - corresponds to the old
+            "min_year"/"max_year" params (same assumption noted in
+            get_vda_evidence above).
+        @min_score/@max_score: float
+            Gene-disease normalized score range, in [0,1].
+        @page_number: int
+            Page number - corresponds to the old "limit"/"offset" params
+            (same auto-loop removal noted in get_vda_evidence above).
+        """
+
+        url = f"{self._api_url}/gda/evidence"
+        get_params = dict()
+
+        if gene_ncbi_id != None:
+            get_params["gene_ncbi_id"] = self._list_to_str(gene_ncbi_id, "Gene NCBI ID", limit=100)
+
+        if gene_symbol != None:
+            get_params["gene_symbol"] = self._list_to_str(gene_symbol, "Gene Symbol", limit=100)
+
+        if disease != None:
+            get_params["disease"] = self._list_to_str(disease, "Disease ID", limit=100)
+
+        if source != None:
+            get_params["source"] = source
+
+        if min_pmYear != None:
+            get_params["min_pmYear"] = min_pmYear
+
+        if max_pmYear != None:
+            get_params["max_pmYear"] = max_pmYear
+
+        if min_score != None:
+            get_params["min_score"] = str(min_score)
+
+        if max_score != None:
+            get_params["max_score"] = str(max_score)
+
+        if page_number != None:
+            get_params["page_number"] = str(page_number)
+
+        return self._retrieve_data(url, get_params)
+    
+    
+    # get_gda_evidences_by_gene() and get_gda_evidences_by_disease() (and
+    # the "gda" branch of the shared _get_evidences()) were removed. They
+    # existed only to select a "by" routing mode (gene vs disease) for the
+    # old path-based /gda/evidences/{by}/... endpoint. The new API has a
+    # single fixed endpoint (/gda/evidence) where gene, disease, chemical,
+    # etc. are all just optional query parameters on the same call, so
+    # there's no more separate URL/routing per identifier type. Replaced
+    # by the single get_gda_evidence() function below, which accepts all
+    # identifier types at once. This also mirrors the same removal already
+    # done for get_vda_evidences_by_variant()/by_disease().
+
+    def get_dda(
+        self,
+        disease_1: Union[str, List[str]],
+        disease_2: Union[str, List[str]],
+        source: Union[str, List[str]] = None,
+        page_number: int = None,
+    ) -> NamedTuple(
+        "DiseaseDiseaseAssociation",
+        [
+            ("disease1_name", str),
+            ("disease2_name", str),
+            ("disease1_classes_do", Tuple[str]),
+            ("disease1_classes_hpo", Tuple[str]),
+            ("disease1_classes_msh", Tuple[str]),
+            ("disease1_classes_umls_st", Tuple[str]),
+            ("disease2_classes_do", Tuple[str]),
+            ("disease2_classes_hpo", Tuple[str]),
+            ("disease2_classes_msh", Tuple[str]),
+            ("disease2_classes_umls_st", Tuple[str]),
+            ("jaccard_genes", float),
+            ("pvalue_jaccard_genes", float),
+            ("jaccard_variants", float),
+            ("pvalue_jaccard_variants", float),
+            ("source", str),
+            ("ngenes1", int),
+            ("ngenes2", int),
+            ("nvariants1", int),
+            ("nvariants2", int),
+            ("shared_genes", int),
+            ("shared_variants", int),
+            ("diseaseid1", str),
+            ("diseaseid2", str),
+        ],
+    ):
+        """
+        Returns Disease-Disease Associations between disease_1 and disease_2.
+        Fields narrowed to the union of what the old
+        get_ddas_that_share_genes()/get_ddas_that_share_variants() returned;
+        the new API returns both gene-sharing and variant-sharing metrics
+        together in a single query, so both jaccard_genes and
+        jaccard_variants are always populated (the old code only returned
+        one or the other depending on which function was called). The old
+        duplicate fields disease1_ngenes/disease2_ngenes/disease1_nvariants/
+        disease2_nvariants (which held the same values as ngenes1/ngenes2/
+        nvariants1/nvariants2) were consolidated into the single generic
+        fields, since the new API only exposes one copy of each.
+
+        @disease_1 / @disease_2: Union[str, List[str]]
+            Disease id(s) with vocabulary prefix, e.g. "UMLS_C0005745".
+        @source: Union[str, List[str]]
+            Source of the DDA.
+        @page_number: int
+            Page number - corresponds to the old "limit" param (100 per
+            page; TRIAL accounts are capped at the top-10 results and do
+            not support pagination).
+        """
+
+        disease_1 = self._list_to_str(disease_1, "Disease 1 ID", limit=100)
+        disease_2 = self._list_to_str(disease_2, "Disease 2 ID", limit=100)
+
+        url = f"{self._api_url}/dda"
+        get_params = dict()
+
+        get_params["disease_1"] = disease_1
+        get_params["disease_2"] = disease_2
+
+        if source != None:
+            get_params["source"] = source
+
+        if page_number != None:
+            get_params["page_number"] = str(page_number)
+
+        result = self._retrieve_data(url, get_params)
+
+        if result == None:
+            return None
+
+        DiseaseDiseaseAssociation = collections.namedtuple(
+            "DiseaseDiseaseAssociation",
+            [
+                "disease1_name",
+                "disease2_name",
+                "disease1_classes_do",
+                "disease1_classes_hpo",
+                "disease1_classes_msh",
+                "disease1_classes_umls_st",
+                "disease2_classes_do",
+                "disease2_classes_hpo",
+                "disease2_classes_msh",
+                "disease2_classes_umls_st",
+                "jaccard_genes",
+                "pvalue_jaccard_genes",
+                "jaccard_variants",
+                "pvalue_jaccard_variants",
+                "source",
+                "ngenes1",
+                "ngenes2",
+                "nvariants1",
+                "nvariants2",
+                "shared_genes",
+                "shared_variants",
+                "diseaseid1",
+                "diseaseid2",
+            ],
+        )
+
+        for index, entry in enumerate(result):
+            result[index] = DiseaseDiseaseAssociation(
+                self._get_string(entry.get("disease1_Name")),
+                self._get_string(entry.get("disease2_Name")),
+                tuple(entry["disease1_Classes_DO"]) if entry.get("disease1_Classes_DO") else None,
+                tuple(entry["disease1_Classes_HPO"]) if entry.get("disease1_Classes_HPO") else None,
+                tuple(entry["disease1_Classes_MSH"]) if entry.get("disease1_Classes_MSH") else None,
+                tuple(entry["disease1_Classes_UMLS_ST"]) if entry.get("disease1_Classes_UMLS_ST") else None,
+                tuple(entry["disease2_Classes_DO"]) if entry.get("disease2_Classes_DO") else None,
+                tuple(entry["disease2_Classes_HPO"]) if entry.get("disease2_Classes_HPO") else None,
+                tuple(entry["disease2_Classes_MSH"]) if entry.get("disease2_Classes_MSH") else None,
+                tuple(entry["disease2_Classes_UMLS_ST"]) if entry.get("disease2_Classes_UMLS_ST") else None,
             
-        if offset != None:
-            get_params["offset"] = offset
-        
-        result = []
-        
-        while True:
-            data = self._retrieve_data(url, get_params)
-            result.extend(data["results"])
-            url = data["next"]
-            
-            if not get_all or url == None:
-                break
+                self._get_float(entry.get("jaccard_genes")),
+                self._get_float(entry.get("pvalue_jaccard_genes")),
+                self._get_float(entry.get("jaccard_variants")),
+                self._get_float(entry.get("pvalue_jaccard_variants")),
+                self._get_string(entry.get("source")),
+                self._get_int(entry.get("ngenes_diseaseID_1")),
+                self._get_int(entry.get("ngenes_diseaseID_2")),
+                self._get_int(entry.get("nvariants_diseaseID_1")),
+                self._get_int(entry.get("nvariants_diseaseID_2")),
+                self._get_int(entry.get("shared_genes")),
+                self._get_int(entry.get("shared_variants")),
+                self._get_string(entry.get("disease1_UMLSCUI")),
+                self._get_string(entry.get("disease2_UMLSCUI")),
+            )
 
         return result
+    # _get_evidences() was removed. It tried to share one generic function
+    # between GDA and VDA evidence retrieval using "of"/"by" flags for
+    # path-based routing (e.g. /vda/evidences/variant/...). The new API
+    # has separate, fixed endpoints (/gda/evidence, /vda/evidence) with
+    # much richer, endpoint-specific parameters (e.g. chromcoord, hgvsc,
+    # hgvsp, min_polyphen for VDA; uniprot_id, nct_phase for GDA), so a
+    # single shared function is no longer a good fit. 
+   
+    
 
     def _list_to_str(
         self, list_obj: List[str], name: str, limit: Optional[int] = None
@@ -1966,8 +830,10 @@ class DisgenetApi:
 
         if isinstance(list_obj, list):
             if limit != None and len(list_obj) > limit:
-                print(f"Maximum length of {name}'s are {limit}.")
-                print(f"First {limit} {name}'s will be used.")
+                _log(
+                    f"DisGeNET maximum length of {name}'s are {limit}, "
+                    f"first {limit} {name}'s will be used."
+                )
 
                 return ",".join(list_obj[:limit])
 
@@ -1975,8 +841,12 @@ class DisgenetApi:
 
         return list_obj
 
-    #@_if_authenticated
-    #@_delete_cache
+    # Re-enabling this decorator: it was previously commented out, which let
+    # _retrieve_data run with no valid api_key and silently send
+    # "Authorization: Bearer None" to the server. Now that authenticate()
+    # is fixed for the new API, this guard is safe to use again.
+    @_if_authenticated
+    @_delete_cache
     def _retrieve_data(
         self, url: str, get_params: Union[List[str], Dict[str, str]]
     ) -> List[Dict[str, str]]:
@@ -1991,24 +861,23 @@ class DisgenetApi:
 
         headers = ["accept: */*", f"Authorization: Bearer {self._api_key}"]
 
-        get_params_extend = list()
+        # Any param whose value is a Python list (e.g. source,
+        # dda_relation, dis_class_list) is expanded into repeated
+        # "key=value" entries, one per list item. This replaces the old
+        # code, which only special-cased a single param named
+        # "disease_class" (which no longer exists in the new API; it's
+        # now "dis_class_list") and would otherwise have serialized any
+        # other list param as a literal Python list string, e.g.
+        # "source=['CURATED', 'CLINVAR']", which the DisGeNET API does
+        # not parse correctly.
+        get_params_list = []
+        for key, value in get_params.items():
+            if isinstance(value, list):
+                get_params_list.extend([f"{key}={item}" for item in value])
+            else:
+                get_params_list.append(f"{key}={value}")
 
-        try:
-            if isinstance(get_params["disease_class"], list):
-                get_params_extend = [
-                    f"disease_class={value}" for value in get_params["disease_class"]
-                ]
-
-                del get_params["disease_class"]
-
-        except KeyError:
-            pass
-
-        get_params["format"] = "json"
-        get_params = [f"{key}={value}" for key, value in get_params.items()]
-
-        if get_params_extend:
-            get_params.extend(get_params_extend)
+        get_params = get_params_list
 
         c = curl.Curl(url=url, get=get_params, req_headers=headers)
 
@@ -2016,9 +885,17 @@ class DisgenetApi:
             result = c.result
             result = json.loads(result)
 
-            return result
+            # The new API wraps the actual records in a "payload" field
+            # alongside status/paging/warnings metadata. The old code
+            # returned the raw parsed JSON as-is, which worked because
+            # the old API's response body WAS the list of records
+            # directly. Every function below expects a plain list of
+            # record dicts, so we extract "payload" here.
+            return result.get("payload")
 
-        print(f"An error occurred with the code {c.status}")
+        _log(f"DisGeNET: an error occurred with the code {c.status}")
+        _log(f"DisGeNET response body: {repr(c.result)}")
+        _log(f"DisGeNET curl object: {vars(c)}")
 
     def _get_int(self, str_obj) -> int:
         """
@@ -2076,64 +953,38 @@ class DisgenetApi:
 
 
 @DisgenetApi._delete_cache
-def variant_gene_mappings() -> (
-    Dict[
-        str,
-        NamedTuple(
-            "VariantGeneMapping",
-            [
-                ("geneId", str),
-                ("geneSymbol", str),
-                ("sourceIds", Tuple[str]),
-            ],
-        ),
-    ]
-):
+def variant_gene_mappings(
+    api: "DisgenetApi",
+    gene_ncbi_ids: List[str],
+    batch_size: int = 10,
+) -> Dict[str, "VariantGeneMapping"]:
     """
-    Downloads and processes variant-gene mappings.
-    Returns a dict where the \'snpId\' is the key.
+    Builds the same {snpId: [VariantGeneMapping(geneId, geneSymbol,
+    sourceIds), ...]} structure the old bulk-download version produced,
+    but queries the new DisGeNET API instead (no bulk mapping file
+    exists anymore).
+
+    Unlike the old version (which took no arguments and downloaded the
+    full DisGeNET variant-gene mapping file), this now requires a list
+    of known NCBI Gene IDs to query against - e.g. from
+    uniprot_adapter.py's xref_geneid field (same source used for
+    disgenet_annotations()). This queries /entity/variant using
+    gene_ncbi_id, which returns each matching variant's own
+    variantToGenes field - a list of {geneNcbiID, symbolOfGene,
+    geneEnsemblID, sources} already grouped per variant, so no manual
+    grouping across rows is needed (unlike the old bulk file, where the
+    same snpId/geneId pair could appear on multiple rows with different
+    sourceId values that had to be accumulated by hand).
+
+    @api: DisgenetApi
+        An already-authenticated DisgenetApi instance.
+    @gene_ncbi_ids: List[str]
+        Known NCBI Gene (Entrez) IDs to query, e.g. ["672", "675", ...].
+    @batch_size: int
+        Number of gene IDs to send per request. Kept small (10) by
+        default to stay safe under TRIAL account limits while testing;
+        raise this once running under a full academic account.
     """
-
-    url = urls.urls["disgenet"]["variant_gene_mappings"]
-    c = curl.Curl(
-        url,
-        silent=False,
-        large=True,
-        encoding="utf-8",
-        default_mode="r",
-    )
-    reader = csv.DictReader(c.result, delimiter="\t")
-    mapping = dict()
-
-    for rec in reader:
-        snpId = rec.pop("snpId")
-
-        try:
-            match = False
-
-            for index, entry in enumerate(mapping[snpId]):
-                if (
-                    rec["geneId"] == entry["geneId"]
-                    and rec["geneSymbol"] == entry["geneSymbol"]
-                ):
-                    match = True
-
-                    if isinstance(mapping[snpId][index]["sourceId"], list):
-                        mapping[snpId][index]["sourceId"].append(rec["sourceId"])
-
-                    else:
-                        mapping[snpId][index]["sourceId"] = [
-                            mapping[snpId][index]["sourceId"],
-                            rec["sourceId"],
-                        ]
-
-                    break
-
-            if not match:
-                mapping[snpId].append(rec)
-
-        except KeyError:
-            mapping[snpId] = [rec]
 
     VariantGeneMapping = collections.namedtuple(
         "VariantGeneMapping",
@@ -2144,57 +995,98 @@ def variant_gene_mappings() -> (
         ],
     )
 
-    for key, values in mapping.items():
-        for index, value in enumerate(values):
-            mapping[key][index] = VariantGeneMapping(
-                value["geneId"],
-                value["geneSymbol"],
-                tuple(value["sourceId"]),
-            )
+    mapping = dict()
+
+    for i in range(0, len(gene_ncbi_ids), batch_size):
+        batch = gene_ncbi_ids[i : i + batch_size]
+        page_number = 0
+
+        while True:
+            url = f"{api._api_url}/entity/variant"
+            get_params = {
+                "gene_ncbi_id": batch,
+                "page_number": str(page_number),
+            }
+
+            result = api._retrieve_data(url, get_params)
+
+            if not result:
+                break
+
+            for entry in result:
+                snp_id = entry.get("strID")
+                variant_to_genes = entry.get("variantToGenes")
+
+                if snp_id == None or not variant_to_genes:
+                    continue
+
+                if snp_id not in mapping:
+                    mapping[snp_id] = []
+
+                for vtg in variant_to_genes:
+                    gene_id = vtg.get("geneNcbiID")
+                    gene_symbol = vtg.get("symbolOfGene")
+                    sources = vtg.get("sources")
+
+                    mapping[snp_id].append(
+                        VariantGeneMapping(
+                            api._get_string(gene_id) if gene_id != None else None,
+                            gene_symbol,
+                            tuple(sources) if sources else None,
+                        )
+                    )
+
+            if len(result) < 100:
+                break
+
+            page_number += 1
 
     return mapping
 
 
 @DisgenetApi._delete_cache
-def disease_id_mappings() -> (
-    dict[
-        str,
-        NamedTuple(
-            "DiseaseIdMapping",
-            [
-                ("name", str),
-                (
-                    "vocabularies",
-                    Tuple[
-                        NamedTuple(
-                            "Vocabulary",
-                            [
-                                ("vocabulary", str),
-                                ("code", str),
-                                ("vocabularyName", str),
-                            ],
-                        )
-                    ],
-                ),
-            ],
-        ),
-    ]
-):
+def disease_id_mappings(
+    api: "DisgenetApi",
+    mondo_ids: List[str],
+    batch_size: int = 10,
+) -> Dict[str, "DiseaseIdMapping"]:
     """
-    Downloads and processes disease-id mappings.
-    Returns a dict where the \'diseaseId\' is the key.
-    """
+    Builds the same {diseaseId: DiseaseIdMapping(name, vocabularies)}
+    structure the old bulk-download version produced, but queries the
+    new DisGeNET API instead (no bulk download endpoint exists anymore).
 
-    url = urls.urls["disgenet"]["disease_id_mappings"]
-    c = curl.Curl(
-        url,
-        silent=False,
-        large=True,
-        encoding="utf-8",
-        default_mode="r",
-    )
-    reader = csv.DictReader(c.result, delimiter="\t")
-    mapping = dict()
+    Unlike the old version (which took no arguments and downloaded the
+    full DisGeNET disease list), this now requires a list of known
+    MONDO disease IDs to query against - e.g. from disease_adapter.py's
+    MONDO ontology download. Each ID must be in the API's expected
+    format, e.g. "MONDO_0007254".
+
+    This is a standalone function (not a DisgenetApi method) so it
+    doesn't change how the class itself is called elsewhere; it takes
+    an already-authenticated DisgenetApi instance as a parameter
+    instead, and calls _retrieve_data directly rather than going
+    through get_gda_summary(), because get_gda_summary()'s narrowed
+    output (matching the old API's fields) doesn't include
+    diseaseVocabularies, which is exactly the field this function needs.
+
+    Note on data shape: /gda/summary returns one row per matching gene
+    for a queried disease, and every row repeats the same disease-level
+    diseaseVocabularies value. We only need that value once per
+    disease, so once a disease_id has been recorded we skip it on
+    subsequent rows - this does not lose any information, since this
+    function was never collecting gene data in the first place (same
+    as the old bulk-file version, which only ever returned name +
+    vocabularies per disease, no gene info).
+
+    @api: DisgenetApi
+        An already-authenticated DisgenetApi instance.
+    @mondo_ids: List[str]
+        Known MONDO disease IDs to query, e.g. ["MONDO_0007254", ...].
+    @batch_size: int
+        Number of disease IDs to send per request. Kept small (10) by
+        default to stay safe under TRIAL account limits while testing;
+        raise this once running under a full academic account.
+    """
 
     Vocabulary = collections.namedtuple(
         "Vocabulary",
@@ -2205,22 +1097,6 @@ def disease_id_mappings() -> (
         ],
     )
 
-    for rec in reader:
-        diseaseId = rec.pop("diseaseId")
-        name = rec.pop("name")
-        rec = Vocabulary(
-            rec["vocabulary"],
-            rec["code"],
-            rec["vocabularyName"],
-        )
-        try:
-            mapping[diseaseId]["vocabularies"].append(rec)
-
-        except KeyError:
-            mapping[diseaseId] = dict()
-            mapping[diseaseId]["name"] = name
-            mapping[diseaseId]["vocabularies"] = [rec]
-
     DiseaseIdMapping = collections.namedtuple(
         "DiseaseIdMapping",
         [
@@ -2229,26 +1105,134 @@ def disease_id_mappings() -> (
         ],
     )
 
-    for key, value in mapping.items():
-        mapping[key] = DiseaseIdMapping(
-            value["name"],
-            tuple(value["vocabularies"]),
-        )
+    mapping = dict()
+
+    for i in range(0, len(mondo_ids), batch_size):
+        batch = mondo_ids[i : i + batch_size]
+        page_number = 0
+
+        while True:
+            url = f"{api._api_url}/gda/summary"
+            get_params = {
+                "disease": batch,
+                "page_number": str(page_number),
+            }
+
+            result = api._retrieve_data(url, get_params)
+
+            if not result:
+                break
+
+            for entry in result:
+                disease_id = entry.get("diseaseUMLSCUI")
+                raw_vocabs = entry.get("diseaseVocabularies")
+
+                if disease_id == None or not raw_vocabs:
+                    continue
+
+                # A disease query returns one row per matching gene;
+                # every row repeats the same disease-level vocabulary
+                # info, so we only process the first occurrence.
+                if disease_id in mapping:
+                    continue
+
+                name = entry.get("diseaseName")
+                vocab_list = []
+
+                for raw in raw_vocabs:
+                    parts = raw.split("_", 1)
+
+                    if len(parts) != 2:
+                        continue
+
+                    vocabulary, code = parts
+                    vocab_list.append(
+                        Vocabulary(
+                            vocabulary,
+                            code,
+                            # The new API only returns short prefixes
+                            # (e.g. "MESH", "MONDO"), not the full
+                            # vocabulary name the old bulk file had
+                            # (e.g. "Medical Subject Headings"). No
+                            # equivalent field exists in the new API
+                            # or the web interface (checked disease
+                            # detail page - it also only shows short
+                            # labels like "MeSH Disease Class", not
+                            # the full vocabulary name), so this is
+                            # left as None rather than guessing.
+                            None,
+                        )
+                    )
+
+                mapping[disease_id] = DiseaseIdMapping(name, tuple(vocab_list))
+
+            if len(result) < 100:
+                break
+
+            page_number += 1
 
     return mapping
 
 
 @DisgenetApi._delete_cache
-def disgenet_annotations(dataset="curated"):
+def disgenet_annotations(
+    api: "DisgenetApi",
+    gene_ncbi_ids: List[str],
+    dataset: str = "curated",
+    batch_size: int = 10,
+) -> Dict[str, set]:
     """
-    Downloads and processes the list of all human disease related proteins
-    from DisGeNet.
-    Returns dict of dicts.
+    Builds the same {uniprot_id: {DisGeNetAnnotation(...), ...}} structure
+    the old bulk-download version produced, but queries the new DisGeNET
+    API instead (no bulk annotation files exist anymore - confirmed via
+    AIDA that curated_gene_disease_associations is no longer available).
 
-    @dataset : str
-        Name of DisGeNet dataset to be obtained:
-        `curated`, `literature`, `befree` or `all`.
+    Unlike the old version (which took no gene list and downloaded the
+    full DisGeNET file, then mapped gene symbols to UniProt via pypath's
+    own mapping.map_name()), this now requires a list of known NCBI Gene
+    IDs to query against - e.g. from uniprot_adapter.py's xref_geneid
+    field. The gene-symbol-to-UniProt translation step is no longer
+    needed: the new API already returns UniProt IDs directly in
+    geneProteinStrIDs, so we read those instead of calling pypath's
+    mapping module.
+
+    This calls _retrieve_data directly rather than get_gda_summary(),
+    because get_gda_summary()'s narrowed output (matching the old
+    _get_gdas() fields) doesn't include numPMIDs or
+    numDBSNPsupportingAssociation, which map to this function's
+    nof_pmids/nof_snps fields and aren't part of the old GDA shape.
+
+    @api: DisgenetApi
+        An already-authenticated DisgenetApi instance.
+    @gene_ncbi_ids: List[str]
+        Known NCBI Gene (Entrez) IDs to query, e.g. ["672", "675", ...].
+    @dataset: str
+        Only "curated" and "all" are supported (mapped to
+        source=["CURATED"] and no source filter, respectively). The old
+        "literature" and "befree" datasets have no clear 1:1 equivalent
+        in the new API's source list (BEFREE no longer exists; the
+        closest match, TEXTMINING_HUMAN/TEXTMINING_MODELS, isn't the
+        same grouping) - flagging this rather than guessing a mapping.
+    @batch_size: int
+        Number of gene IDs to send per request. Kept small (10) by
+        default to stay safe under TRIAL account limits while testing;
+        raise this once running under a full academic account.
     """
+
+    dataset_source_map = {
+        "curated": ["CURATED"],
+        "all": None,
+    }
+
+    if dataset not in dataset_source_map:
+        _log(
+            f"DisGeNET dataset='{dataset}' is not supported. Only 'curated' and "
+            "'all' are mapped to the new API's source filter; 'literature' "
+            "and 'befree' have no clear equivalent in the new source list."
+        )
+        return None
+
+    source = dataset_source_map[dataset]
 
     DisGeNetAnnotation = collections.namedtuple(
         "DisGeNetAnnotation",
@@ -2264,39 +1248,68 @@ def disgenet_annotations(dataset="curated"):
         ],
     )
 
-    url = urls.urls["disgenet"]["annotations"] % dataset
-    c = curl.Curl(
-        url,
-        silent=False,
-        large=True,
-        encoding="utf-8",
-        default_mode="r",
-    )
-    reader = csv.DictReader(c.result, delimiter="\t")
     data = collections.defaultdict(set)
 
-    for rec in reader:
-        uniprots = mapping.map_name(
-            rec["geneSymbol"],
-            "genesymbol",
-            "uniprot",
-        )
+    for i in range(0, len(gene_ncbi_ids), batch_size):
+        batch = gene_ncbi_ids[i : i + batch_size]
+        page_number = 0
 
-        if not uniprots:
-            continue
+        while True:
+            url = f"{api._api_url}/gda/summary"
+            get_params = {
+                "gene_ncbi_id": batch,
+                "page_number": str(page_number),
+            }
 
-        for uniprot in uniprots:
-            data[uniprot].add(
-                DisGeNetAnnotation(
-                    disease=rec["diseaseName"],
-                    type=rec["diseaseType"],
-                    score=float(rec["score"]),
-                    dsi=float(rec["DSI"]) if rec["DSI"] else None,
-                    dpi=float(rec["DPI"]) if rec["DPI"] else None,
-                    nof_pmids=int(rec["NofPmids"]),
-                    nof_snps=int(rec["NofSnps"]),
-                    source=tuple(x.strip() for x in rec["source"].split(";")),
+            if source != None:
+                get_params["source"] = source
+
+            result = api._retrieve_data(url, get_params)
+
+            if not result:
+                break
+
+            for entry in result:
+                uniprot_ids = entry.get("geneProteinStrIDs")
+
+                if not uniprot_ids:
+                    continue
+
+                disease = entry.get("diseaseName")
+                disease_type = entry.get("diseaseType")
+                score = entry.get("score")
+                dsi = entry.get("geneDSI")
+                dpi = entry.get("geneDPI")
+                nof_pmids = entry.get("numPMIDs")
+                nof_snps = entry.get("numDBSNPsupportingAssociation")
+
+                # The new /gda/summary response does not include a
+                # per-record source field (unlike the old API's
+                # GeneDiseaseAssociation, which had one). When a single
+                # source filter was requested (dataset="curated"), that
+                # filter is the only source these aggregated results
+                # could have come from, so we record it as such. For
+                # dataset="all" (no filter), the true per-record source
+                # is unknown, so this is left as None.
+                record_source = tuple(source) if source != None else None
+
+                annotation = DisGeNetAnnotation(
+                    disease,
+                    disease_type,
+                    api._get_float(score) if score != None else None,
+                    api._get_float(dsi) if dsi != None else None,
+                    api._get_float(dpi) if dpi != None else None,
+                    api._get_int(nof_pmids) if nof_pmids != None else None,
+                    api._get_int(nof_snps) if nof_snps != None else None,
+                    record_source,
                 )
-            )
+
+                for uniprot in uniprot_ids:
+                    data[uniprot].add(annotation)
+
+            if len(result) < 100:
+                break
+
+            page_number += 1
 
     return dict(data)


### PR DESCRIPTION
What changed
   Auth: static API key (Authorization: Bearer) instead of email/password + session token. Re-enabled _if_authenticated/_delete_cache decorators on _retrieve_data (previously disabled, letting requests go out with no valid key).
   _retrieve_data: removed a format=json param the new API rejects (root cause of most 400s during testing), added .get("payload") extraction for the new response envelope, generalized list-param handling, switched print() to _log(). 
   Rewrote 5 core functions against the new endpoints: get_dda, get_gda_summary, get_vda_summary, get_gda_evidence, get_vda_evidence (replacing the old get_*_by_* variants). Fields narrowed to match what the old functions returned.
   Rebuilt 3 bulk-download functions on the API, since no bulk files exist anymore: disease_id_mappings, disgenet_annotations, variant_gene_mappings — now take a list of known IDs (from other adapters) instead of downloading full files.

known gaps:
source is mostly returned none, it allows query filter as intended 
Pagination beyond page 0 untested (TRIAL account doesn't support it).