### PR TITLE
kegg_local and disease_adapter fixes

### DIFF
--- a/bccb/disease_adapter.py
+++ b/bccb/disease_adapter.py
@@ -23,6 +23,7 @@ import h5py
 from pypath.inputs import ontology
 from pypath.formats import obo
 from pypath.utils import mapping
+from pypath.utils import go as go_util
 from pypath.share import cache
 
 from typing import Union
@@ -95,6 +96,7 @@ class DiseaseNodeField(Enum, metaclass=DiseaseEnumMeta):
 
 class DiseaseEdgeType(Enum, metaclass=DiseaseEnumMeta):
     MONDO_HIERARCHICAL_RELATIONS = auto()
+    MONDO_CROSS_ONTOLOGY_RELATIONS = auto()
     ORGANISM_TO_DISEASE = auto()
     GENE_TO_DISEASE = auto()
     DISEASE_TO_DRUG = auto()
@@ -319,24 +321,408 @@ class Disease:
             f"Mondo data is downloaded in {round((t1-t0) / 60, 2)} mins"
         )
 
-        if DiseaseEdgeType.MONDO_HIERARCHICAL_RELATIONS in self.edge_types:
+        mondo_hierarchy_requested = (
+            DiseaseEdgeType.MONDO_HIERARCHICAL_RELATIONS
+            in self.edge_types
+        )
+
+        mondo_cross_ontology_requested = (
+            DiseaseEdgeType.MONDO_CROSS_ONTOLOGY_RELATIONS
+            in self.edge_types
+        )
+
+        if (
+            mondo_hierarchy_requested
+            or mondo_cross_ontology_requested
+        ):
             t0 = time()
 
-            mondo_obo_reader = obo.Obo(
-                "http://purl.obolibrary.org/obo/mondo.obo"
+            mondo_url = (
+                "https://purl.obolibrary.org/obo/mondo.obo"
             )
 
-            mondo_obo_reader.parent_terms()
+            # =====================================================
+            # is_a RELATIONS
+            # =====================================================
 
-            self.mondo_hierarchical_relations = {
-                k: v for k, v in mondo_obo_reader.parents.items() if v
-            }
+            hierarchy_reader = obo.Obo(mondo_url)
+
+            hierarchy_reader.parent_terms()
+
+            self.mondo_hierarchical_relations = {}
+
+            cross_ontology_relations = []
+
+            for child, parent_ids in (
+                hierarchy_reader.parents.items()
+            ):
+                if not (
+                    isinstance(child, str)
+                    and child.startswith("MONDO:")
+                ):
+                    continue
+
+                mondo_parents = []
+
+                for parent in parent_ids:
+                    if not isinstance(parent, str):
+                        continue
+
+                    # MONDO -> MONDO hierarchy
+                    if parent.startswith("MONDO:"):
+                        mondo_parents.append(parent)
+
+                    # MONDO -> another ontology
+                    elif (
+                        mondo_cross_ontology_requested
+                        and ":" in parent
+                    ):
+                        cross_ontology_relations.append(
+                            {
+                                "source_id": child,
+                                "relation": "is_a",
+                                "target_id": parent,
+                                "target_ontology": (
+                                    parent.split(":", 1)[0]
+                                ),
+                            }
+                        )
+
+                if (
+                    mondo_hierarchy_requested
+                    and mondo_parents
+                ):
+                    self.mondo_hierarchical_relations[
+                        child
+                    ] = mondo_parents
+
+            # =====================================================
+            # EXPLICIT relationship: RELATIONS
+            # =====================================================
+
+            if mondo_cross_ontology_requested:
+
+                # Separate reader is intentional.
+                relationship_reader = obo.Obo(mondo_url)
+
+                external_term_names = {}
+
+                for term in relationship_reader:
+
+                    if term.stanza != "Term":
+                        continue
+
+                    if not term.id:
+                        continue
+
+                    term_id = term.id.value
+
+                    term_name = None
+
+                    if getattr(term, "name", None):
+                        term_name = getattr(
+                            term.name,
+                            "value",
+                            None,
+                        )
+
+                    if term_name:
+                        external_term_names[
+                            term_id
+                        ] = term_name
+
+                    source_id = term_id
+
+                    if not (
+                        isinstance(source_id, str)
+                        and source_id.startswith("MONDO:")
+                    ):
+                        continue
+
+                    # =====================================================
+                    # EXPLICIT relationship: FIELDS
+                    # =====================================================
+
+                    relationships = term.attrs.get(
+                        "relationship",
+                        set(),
+                    )
+
+                    for relationship in relationships:
+
+                        relation_type = relationship.value
+
+                        # This is metadata, not a biological / ontological
+                        # relationship that should become a KG edge.
+                        if (
+                            relation_type
+                            == "curated_content_resource"
+                        ):
+                            continue
+
+                        if not relationship.modifiers:
+                            continue
+
+                        target_id = (
+                            relationship.modifiers
+                            .strip()
+                            .split()[0]
+                        )
+
+                        if not target_id:
+                            continue
+
+                        # Internal MONDO relationship.
+                        # MONDO -> MONDO hierarchy is already handled
+                        # separately via parent_terms().
+                        if target_id.startswith("MONDO:"):
+                            continue
+
+                        # Ignore URLs and malformed/non-CURIE targets.
+                        if (
+                            target_id.startswith("http://")
+                            or target_id.startswith("https://")
+                            or ":" not in target_id
+                        ):
+                            continue
+
+                        target_ontology = (
+                            target_id.split(":", 1)[0]
+                        )
+
+                        cross_ontology_relations.append(
+                            {
+                                "source_id": source_id,
+                                "relation": relation_type,
+                                "target_id": target_id,
+                                "target_ontology": target_ontology,
+                            }
+                        )
+
+                # ================================================
+                # REMOVE DUPLICATES
+                # ================================================
+
+                unique_relations = {}
+
+                for relation in cross_ontology_relations:
+
+                    key = (
+                        relation["source_id"],
+                        relation["relation"],
+                        relation["target_id"],
+                    )
+
+                    unique_relations[key] = relation
+
+                self.mondo_cross_ontology_relations = list(
+                    unique_relations.values()
+                )
+                target_ids = {
+                    relation["target_id"]
+                    for relation
+                    in self.mondo_cross_ontology_relations
+                }
+
+                self.mondo_external_term_names = {
+                    target_id: external_term_names.get(
+                        target_id
+                    )
+                    for target_id in target_ids
+                }
+
+                ontology_counts = collections.Counter(
+                    relation["target_ontology"]
+                    for relation
+                    in self.mondo_cross_ontology_relations
+                )
+
+                logger.info(
+                    "MONDO contains "
+                    f"{len(self.mondo_cross_ontology_relations)} "
+                    "cross-ontology relations"
+                )
+
+                for ontology_name, count in (
+                    ontology_counts.most_common()
+                ):
+                    logger.info(
+                        f"MONDO -> {ontology_name}: "
+                        f"{count} relations"
+                    )
+
+            # =====================================================
+            # MONDO HIERARCHY LOGGING
+            # =====================================================
+
+            if mondo_hierarchy_requested:
+
+                mondo_hierarchy_edge_count = sum(
+                    len(parent_ids)
+                    for parent_ids
+                    in self.mondo_hierarchical_relations.values()
+                )
+
+                logger.info(
+                    "MONDO hierarchy contains "
+                    f"{len(self.mondo_hierarchical_relations)} "
+                    "child terms and "
+                    f"{mondo_hierarchy_edge_count} "
+                    "direct is_a relations"
+                )
 
             t1 = time()
+
             logger.info(
-                f"Mondo hierarchical relations data is downloaded in {round((t1-t0) / 60, 2)} mins"
+                "MONDO ontology relations are downloaded "
+                f"in {round((t1 - t0) / 60, 2)} mins"
             )
 
+
+    def get_mondo_cross_ontology_relations(
+        self,
+        target_ontology: str | None = None,
+        relation_type: str | None = None,
+    ) -> list[dict]:
+        """
+        Return MONDO relations targeting terms from external
+        ontologies.
+
+        Optionally filter by target ontology and/or relation type.
+        """
+
+        if not hasattr(
+            self,
+            "mondo_cross_ontology_relations",
+        ):
+            if (
+                DiseaseEdgeType.MONDO_CROSS_ONTOLOGY_RELATIONS
+                not in self.edge_types
+            ):
+                raise ValueError(
+                    "MONDO_CROSS_ONTOLOGY_RELATIONS must be "
+                    "included in edge_types."
+                )
+
+            self.download_mondo_data()
+
+        relations = self.mondo_cross_ontology_relations
+
+        if target_ontology is not None:
+            target_ontology = target_ontology.upper()
+
+            relations = [
+                relation
+                for relation in relations
+                if (
+                    relation["target_ontology"].upper()
+                    == target_ontology
+                )
+            ]
+
+        if relation_type is not None:
+            relations = [
+                relation
+                for relation in relations
+                if (
+                    relation["relation"]
+                    == relation_type
+                )
+            ]
+
+        return relations
+
+    @validate_call
+    def get_mondo_external_ontology_nodes(
+        self,
+        label: str = "external ontology term",
+    ) -> list[tuple]:
+        """
+        Generate nodes for MONDO cross-ontology targets which
+        do not already have a dedicated CROssBAR node adapter.
+
+        HP, GO and NCBITaxon are excluded because they already
+        exist as dedicated node types in CROssBAR.
+        """
+
+        if not hasattr(
+            self,
+            "mondo_cross_ontology_relations",
+        ):
+            self.download_mondo_data()
+
+        logger.debug(
+            "Started writing MONDO external ontology nodes"
+        )
+
+        dedicated_ontologies = {
+            "HP",
+            "GO",
+            "NCBITAXON",
+        }
+
+        external_targets = {}
+
+        for relation in (
+            self.mondo_cross_ontology_relations
+        ):
+            ontology = relation[
+                "target_ontology"
+            ]
+
+            if (
+                ontology.upper()
+                in dedicated_ontologies
+            ):
+                continue
+
+            target_id = relation[
+                "target_id"
+            ]
+
+            external_targets[
+                target_id
+            ] = ontology
+
+        node_list = []
+
+        for target_id, ontology in (
+            external_targets.items()
+        ):
+            normalized_id = (
+                normalize_curie(target_id)
+                or target_id
+            )
+
+            props = {
+                "ontology": ontology,
+            }
+
+            term_name = (
+                getattr(
+                    self,
+                    "mondo_external_term_names",
+                    {},
+                ).get(target_id)
+            )
+
+            if term_name:
+                props["name"] = term_name
+
+            node_list.append(
+                (
+                    normalized_id,
+                    label,
+                    props,
+                )
+            )
+
+        logger.info(
+            f"Generated {len(node_list)} "
+            "external ontology term nodes"
+        )
+
+        return node_list
     def download_pathophenodb_data(self) -> None:
         if DiseaseEdgeType.ORGANISM_TO_DISEASE in self.edge_types:
             t0 = time()
@@ -1954,21 +2340,131 @@ class Disease:
 
                 if self.early_stopping and index == self.early_stopping:
                     break
-
+        if (
+            DiseaseEdgeType.MONDO_CROSS_ONTOLOGY_RELATIONS
+            in self.edge_types
+        ):
+            node_list.extend(
+                self.get_mondo_external_ontology_nodes()
+            )            
         # write node data to csv
+        # ============================================================
+        # WRITE NODE DATA TO CSV
+        # ============================================================
+
         if self.export_csv:
-            if self.output_dir:
-                full_path = os.path.join(self.output_dir, "Disease.csv")
-            else:
-                full_path = os.path.join(os.getcwd(), "Disease.csv")
 
-            df_list = [
-                {"disease_id": _id} | props for _id, _, props in node_list
+            output_dir = (
+                self.output_dir
+                if self.output_dir
+                else os.getcwd()
+            )
+
+            # --------------------------------------------------------
+            # DISEASE NODES
+            # --------------------------------------------------------
+
+            disease_records = [
+                {
+                    "disease_id": node_id,
+                    **props,
+                }
+                for (
+                    node_id,
+                    node_label,
+                    props,
+                ) in node_list
+                if node_label == label
             ]
-            df = pd.DataFrame.from_records(df_list)
-            df.to_csv(full_path, index=False)
-            logger.info(f"Disease node data is written: {full_path}")
 
+            if disease_records:
+
+                disease_path = os.path.join(
+                    output_dir,
+                    "Disease.csv",
+                )
+
+                disease_df = (
+                    pd.DataFrame.from_records(
+                        disease_records
+                    )
+                )
+
+                disease_df.to_csv(
+                    disease_path,
+                    index=False,
+                )
+
+                logger.info(
+                    "Disease node data is written: "
+                    f"{disease_path}"
+                )
+
+            # --------------------------------------------------------
+            # EXTERNAL ONTOLOGY TERM NODES
+            # --------------------------------------------------------
+
+            external_records = [
+                {
+                    "external_ontology_term_id":
+                        node_id,
+                    **props,
+                }
+                for (
+                    node_id,
+                    node_label,
+                    props,
+                ) in node_list
+                if (
+                    node_label
+                    == "external ontology term"
+                )
+            ]
+
+            if external_records:
+
+                external_path = os.path.join(
+                    output_dir,
+                    "External_ontology_term.csv",
+                )
+
+                external_df = (
+                    pd.DataFrame.from_records(
+                        external_records
+                    )
+                )
+
+                external_df.to_csv(
+                    external_path,
+                    index=False,
+                )
+
+                logger.info(
+                    "External ontology term node "
+                    f"data is written: {external_path}"
+                )
+
+            # --------------------------------------------------------
+            # DEFENSIVE CHECK
+            # --------------------------------------------------------
+
+            expected_labels = {
+                label,
+                "external ontology term",
+            }
+
+            unexpected_labels = {
+                node_label
+                for _, node_label, _ in node_list
+                if node_label not in expected_labels
+            }
+
+            if unexpected_labels:
+                logger.warning(
+                    "Unexpected node labels during "
+                    "Disease adapter CSV export: "
+                    f"{sorted(unexpected_labels)}"
+                )
         return node_list
 
     @validate_call
@@ -1996,6 +2492,8 @@ class Disease:
 
         if DiseaseEdgeType.MONDO_HIERARCHICAL_RELATIONS in self.edge_types:
             edge_list.extend(self.get_mondo_hiererchical_edges(mondo_hierarchy_label))
+        if ( DiseaseEdgeType.MONDO_CROSS_ONTOLOGY_RELATIONS in self.edge_types ):
+            edge_list.extend(self.get_mondo_cross_ontology_edges())
 
         if DiseaseEdgeType.ORGANISM_TO_DISEASE in self.edge_types:
             edge_list.extend(self.get_organism_disease_edges(organism_to_disease_label))
@@ -2049,6 +2547,340 @@ class Disease:
             logger.info(f"Mondo hiererchical edge data is written: {full_path}")
 
         return edge_list
+    
+    @validate_call
+    def get_mondo_cross_ontology_edges(
+        self,
+        target_ontologies: list[str] | None = None,
+        phenotype_label: str = (
+            "disease_has_mondo_relation_to_phenotype"
+        ),
+        organism_label: str = (
+            "disease_has_mondo_relation_to_organism"
+        ),
+        biological_process_label: str = (
+            "disease_has_mondo_relation_to_biological_process"
+        ),
+        cellular_component_label: str = (
+            "disease_has_mondo_relation_to_cellular_component"
+        ),
+        molecular_function_label: str = (
+            "disease_has_mondo_relation_to_molecular_function"
+        ),
+        external_ontology_label: str = (
+            "disease_has_mondo_relation_to_external_ontology_term"
+        ),
+    ) -> list[tuple]:
+
+        if not hasattr(
+            self,
+            "mondo_cross_ontology_relations",
+        ):
+            self.download_mondo_data()
+
+        logger.debug(
+            "Started writing MONDO cross-ontology edges"
+        )
+
+        # =========================================================
+        # OPTIONAL FILTER
+        #
+        # None means: include ALL target ontologies.
+        # =========================================================
+
+        if target_ontologies is None:
+            requested_ontologies = None
+        else:
+            requested_ontologies = {
+                ontology.upper()
+                for ontology in target_ontologies
+            }
+
+        # =========================================================
+        # LOAD GO ONLY WHEN NEEDED
+        # =========================================================
+
+        go_requested = (
+            requested_ontologies is None
+            or "GO" in requested_ontologies
+        )
+
+        if (
+            go_requested
+            and not hasattr(
+                self,
+                "mondo_go_ontology",
+            )
+        ):
+            logger.info(
+                "Loading Gene Ontology for "
+                "MONDO GO target typing"
+            )
+
+            self.mondo_go_ontology = (
+                go_util.GeneOntology()
+            )
+
+        go_aspect_to_label = {
+            "P": biological_process_label,
+            "C": cellular_component_label,
+            "F": molecular_function_label,
+        }
+
+        edge_list = []
+
+        unknown_go_aspects = []
+        invalid_relations = []
+
+        # =========================================================
+        # GENERATE EDGES
+        # =========================================================
+
+        for relation in tqdm(
+            self.mondo_cross_ontology_relations
+        ):
+
+            source_raw = relation.get(
+                "source_id"
+            )
+
+            target_raw = relation.get(
+                "target_id"
+            )
+
+            target_ontology = relation.get(
+                "target_ontology"
+            )
+
+            mondo_relation = relation.get(
+                "relation"
+            )
+
+            # -----------------------------------------------------
+            # Basic validation
+            # -----------------------------------------------------
+
+            if not (
+                isinstance(source_raw, str)
+                and isinstance(target_raw, str)
+                and isinstance(target_ontology, str)
+                and isinstance(mondo_relation, str)
+            ):
+                invalid_relations.append(
+                    relation
+                )
+                continue
+
+            ontology_key = (
+                target_ontology.upper()
+            )
+
+            # -----------------------------------------------------
+            # Apply filter ONLY when a filter was requested
+            # -----------------------------------------------------
+
+            if (
+                requested_ontologies is not None
+                and ontology_key
+                not in requested_ontologies
+            ):
+                continue
+
+            source_id = (
+                normalize_curie(source_raw)
+                or source_raw
+            )
+
+            target_id = (
+                normalize_curie(target_raw)
+                or target_raw
+            )
+
+            # =====================================================
+            # HP
+            # =====================================================
+
+            if ontology_key == "HP":
+
+                label = phenotype_label
+
+            # =====================================================
+            # NCBITaxon
+            # =====================================================
+
+            elif ontology_key == "NCBITAXON":
+
+                label = organism_label
+
+            # =====================================================
+            # GO
+            # =====================================================
+
+            elif ontology_key == "GO":
+
+                go_aspect = (
+                    self.mondo_go_ontology
+                    .aspect
+                    .get(target_raw)
+                )
+
+                if go_aspect is None:
+
+                    go_aspect = (
+                        self.mondo_go_ontology
+                        .aspect
+                        .get(
+                            target_raw.removeprefix(
+                                "GO:"
+                            )
+                        )
+                    )
+
+                label = (
+                    go_aspect_to_label.get(
+                        go_aspect
+                    )
+                )
+
+                if label is None:
+
+                    unknown_go_aspects.append(
+                        {
+                            "source_id": source_raw,
+                            "target_id": target_raw,
+                            "relation": mondo_relation,
+                        }
+                    )
+
+                    continue
+
+            # =====================================================
+            # EVERYTHING ELSE
+            #
+            # UBERON
+            # CHR
+            # CL
+            # PATO
+            # CHEBI
+            # ECTO
+            # SO
+            # NCIT
+            # ENVO
+            # ...
+            # =====================================================
+
+            else:
+
+                label = external_ontology_label
+
+            # =====================================================
+            # PROPERTIES
+            # =====================================================
+
+            props = {
+                "source": "MONDO",
+                "mondo_relation": mondo_relation,
+                "target_ontology": target_ontology,
+            }
+
+            edge_list.append(
+                (
+                    None,
+                    source_id,
+                    target_id,
+                    label,
+                    props,
+                )
+            )
+
+            if (
+                self.early_stopping
+                and len(edge_list)
+                >= self.early_stopping
+            ):
+                break
+
+        # =========================================================
+        # LOGGING
+        # =========================================================
+
+        logger.info(
+            f"Generated {len(edge_list)} "
+            "MONDO cross-ontology edges"
+        )
+
+        if invalid_relations:
+
+            logger.warning(
+                f"{len(invalid_relations)} invalid "
+                "MONDO cross-ontology records "
+                "were skipped"
+            )
+
+        if unknown_go_aspects:
+
+            logger.warning(
+                f"{len(unknown_go_aspects)} GO targets "
+                "could not be assigned to a GO aspect"
+            )
+
+            for relation in (
+                unknown_go_aspects[:10]
+            ):
+                logger.warning(
+                    f"Unknown GO target: {relation}"
+                )
+
+        # =========================================================
+        # CSV EXPORT
+        # =========================================================
+
+        if self.export_csv:
+
+            if self.output_dir:
+                full_path = os.path.join(
+                    self.output_dir,
+                    "Mondo_cross_ontology_edges.csv",
+                )
+            else:
+                full_path = os.path.join(
+                    os.getcwd(),
+                    "Mondo_cross_ontology_edges.csv",
+                )
+
+            df_list = [
+                {
+                    "source_id": source,
+                    "target_id": target,
+                    "label": label,
+                    **props,
+                }
+                for (
+                    _,
+                    source,
+                    target,
+                    label,
+                    props,
+                ) in edge_list
+            ]
+
+            df = pd.DataFrame.from_records(
+                df_list
+            )
+
+            df.to_csv(
+                full_path,
+                index=False,
+            )
+
+            logger.info(
+                "MONDO cross-ontology edge data "
+                f"is written: {full_path}"
+            )
+
+        return edge_list
+
+    
 
     @validate_call
     def get_organism_disease_edges(
@@ -2263,16 +3095,44 @@ class Disease:
 
     @validate_call
     def add_prefix_to_id(
-        self, prefix: str = None, identifier: str = None, sep: str = ":"
-    ) -> str:
+        self,
+        prefix: str | None = None,
+        identifier: str | None = None,
+        sep: str = ":",
+    ) -> str | None:
         """
-        Adds prefix to database id
+        Add a prefix to an identifier when needed.
+
+        If the identifier is already a CURIE, it is normalized
+        without adding the prefix again.
         """
-        if self.add_prefix and identifier:
-            return normalize_curie(prefix + sep + identifier)
 
-        return identifier
+        if not identifier:
+            return identifier
 
+        if not self.add_prefix:
+            return identifier
+
+        identifier = str(identifier)
+
+        # Identifier already has a prefix.
+        if ":" in identifier:
+            return (
+                normalize_curie(identifier)
+                or identifier
+            )
+
+        if not prefix:
+            return identifier
+
+        curie = (
+            f"{prefix}{sep}{identifier}"
+        )
+
+        return (
+            normalize_curie(curie)
+            or curie
+        )
     def merge_source_column(self, element, joiner="|"):
 
         _list = []

--- a/bccb/kegg_local.py
+++ b/bccb/kegg_local.py
@@ -14,9 +14,53 @@ from collections.abc import Iterable
 import pypath.resources.urls as urls
 from pypath.share import curl
 
+import asyncio
+import aiohttp
+import warnings
+import random
+
+from dataclasses import dataclass
+from typing import Optional
+import json
+
+
+
+
+DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=30)
+DDI_BATCH_SIZE = 500
+
 _url = urls.urls['kegg_api']['url']
 
+class AsyncRateLimiter:
+    """
+    Ensures that requests are started no faster than the configured rate.
+    """
+
+    def __init__(self, requests_per_second: float = 2.0):
+        if requests_per_second <= 0:
+            raise ValueError(
+                "requests_per_second must be greater than zero."
+            )
+
+        self.minimum_interval = 1.0 / requests_per_second
+        self._lock = asyncio.Lock()
+        self._last_request_time = 0.0
+
+    async def wait(self) -> None:
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            current_time = loop.time()
+
+            elapsed = current_time - self._last_request_time
+            remaining = self.minimum_interval - elapsed
+
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+
+            self._last_request_time = loop.time()
+
 def gene_to_pathway(org):
+
 
     return _kegg_from_source_to_target('gene', 'pathway', org)
 
@@ -103,9 +147,6 @@ def drug_to_drug(
     drug = _Drug()
     compound = _Compound()
 
-    if asynchronous:
-        warnings.warn('Async is not implemented for now. Defaulting to False...')
-        asynchronous = False
     
     if drugs != None:
 
@@ -113,8 +154,7 @@ def drug_to_drug(
 
     else:
         drugIds = drug.get_data().keys()
-        # Async will be false until it gets implemented properly
-        entries = _kegg_ddi(drugIds, join=False, asynchronous=False)
+        entries = _kegg_ddi(drugIds, join=False, asynchronous=asynchronous)
 
     interactions = dict()
 
@@ -320,28 +360,155 @@ def _kegg_general(operation, *arguments, split=True):
         return []
 
 
-async def _kegg_general_async(operation, *arguments):
 
-    #TODO Yet to be implemented
-    # This function doesn't work but it better
-    # stay so we can implement it without
-    # changing the structure of the module
+async def _fetch_with_retry(
+    session: aiohttp.ClientSession,
+    semaphore: asyncio.Semaphore,
+    rate_limiter: AsyncRateLimiter,
+    operation: str,
+    identifier: str,
+    retries: int = 3,
+):
 
-    return None
 
     url = _url % operation
+    url += f"/{identifier}"
 
-    for argument in arguments:
+    last_exception = None
 
-        url += f'/{argument}'
+    for attempt in range(1, retries + 1):
 
-    c = await curl.Curl(url, silent = True, large = False)
+        try:
 
-    try:
-        return [line.split('\t') if split else line for line in c.result.split('\n') if line]
-    except AttributeError:
-        return []
+            await rate_limiter.wait()
 
+            async with semaphore:
+
+                async with session.get(url) as response:
+
+                    status = response.status
+
+                    response.raise_for_status()
+
+                    text = await response.text()
+
+                    return RequestResult(
+                        identifier=identifier,
+                        endpoint=operation,
+                        success=True,
+                        retries=attempt,
+                        status_code=status,
+                        error=None,
+                        data=[
+                            line.split("\t")
+                            for line in text.splitlines()
+                            if line
+                        ],
+                    )
+
+        except aiohttp.ClientResponseError as e:
+
+            last_exception = e
+
+            # 404 -> DDI kaydı yok, retry yapma
+            if e.status == 404:
+
+                return RequestResult(
+                    identifier=identifier,
+                    endpoint=operation,
+                    success=False,
+                    retries=attempt,
+                    status_code=e.status,
+                    error=str(e),
+                    data=[],
+                )
+
+            # 403 -> Rate limit olabilir, daha uzun bekle
+            if e.status == 403:
+
+                if attempt < retries:
+
+                    retry_after = e.headers.get("Retry-After")
+
+                    if retry_after is not None:
+
+                        wait = float(retry_after)
+
+                    else:
+
+                        wait = (5 * attempt) + random.uniform(0, 2)
+
+                    print(
+                        f"[403] {identifier} "
+                        f"(attempt {attempt}/{retries}) "
+                        f"retrying in {wait:.1f}s"
+                    )
+
+                    await asyncio.sleep(wait)
+
+                    continue
+
+            # Diğer HTTP hataları (500, 502, vb.)
+            if attempt < retries:
+
+                wait = (2 ** (attempt - 1)) + random.uniform(0, 1)
+
+                print(
+                    f"[HTTP {e.status}] {identifier} "
+                    f"(attempt {attempt}/{retries}) "
+                    f"retrying in {wait:.1f}s"
+                )
+
+                await asyncio.sleep(wait)
+
+        except (
+            aiohttp.ClientError,
+            asyncio.TimeoutError,
+        ) as e:
+
+            last_exception = e
+
+            if attempt < retries:
+                await asyncio.sleep((2 ** (attempt - 1)) + random.random())
+
+    status = (
+        getattr(last_exception, "status", None)
+        if last_exception
+        else None
+    )
+
+    return RequestResult(
+        identifier=identifier,
+        endpoint=operation,
+        success=False,
+        retries=retries,
+        status_code=status,
+        error=repr(last_exception),
+        data=[],
+    )
+
+async def _kegg_general_async(
+    session: aiohttp.ClientSession,
+    semaphore: asyncio.Semaphore,
+    rate_limiter: AsyncRateLimiter,
+    operation: str,
+    *arguments,
+):
+
+
+    if len(arguments) != 1:
+
+        raise ValueError(
+            "_kegg_general_async currently supports a single identifier."
+        )
+
+    return await _fetch_with_retry(
+        session=session,
+        semaphore=semaphore,
+        rate_limiter=rate_limiter,
+        operation=operation,
+        identifier=arguments[0],
+    )
 
 def _kegg_list(database, option=None, org=None):
 
@@ -407,15 +574,11 @@ def _kegg_link(source_db, target_db):
 def _kegg_ddi(drugIds, join=True, asynchronous=False):
 
     if join and not isinstance(drugIds, str):
-
         drugIds = ['+'.join(drugIds)]
 
     if asynchronous:
+        return asyncio.run(_kegg_ddi_async(drugIds))
 
-        pool = ThreadPoolExecutor()
-
-        return pool.submit(asyncio.run, _kegg_ddi_async(drugIds)).result()
-        
     return _kegg_ddi_sync(drugIds)
 
 
@@ -432,23 +595,184 @@ def _kegg_ddi_sync(drugIds):
         return result
 
 
-async def _kegg_ddi_async(drugIds):
+async def _kegg_ddi_async(
+    drugIds,
+    batch_size=25,
+    concurrency=2,
+    requests_per_second=2.0,
+):
+    result = []
 
-    #TODO Yet to be implemented
-    # This function doesn't work but it better
-    # stay so we can implement it without
-    # changing the structure of the module
+    stats = {
+        "success_first_try": 0,
+        "success_after_retry": 0,
+        "not_found": 0,
+        "failed": 0,
+    }
 
-    result = list()
+    status_counter = {}
+    failures = []
 
-    if isinstance(drugIds, Iterable):
+    timeout = aiohttp.ClientTimeout(total=30)
 
-        for response in asyncio.as_completed([_kegg_general_async('ddi', drugId) for drugId in drugIds]):
-            response = await response
-            result.extend(response)
+    semaphore = asyncio.Semaphore(concurrency)
 
-        return result
+    rate_limiter = AsyncRateLimiter(
+        requests_per_second=requests_per_second
+    )
 
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+
+        for batch_start in range(
+            0,
+            len(drugIds),
+            batch_size,
+        ):
+            batch = drugIds[
+                batch_start:
+                batch_start + batch_size
+            ]
+
+            tasks = [
+                _kegg_general_async(
+                    session,
+                    semaphore,
+                    rate_limiter,
+                    "ddi",
+                    drug_id,
+                )
+                for drug_id in batch
+            ]
+
+            batch_results = await asyncio.gather(
+                *tasks,
+                return_exceptions=True,
+            )
+
+            for request in batch_results:
+
+                if isinstance(request, Exception):
+                    warnings.warn(
+                        f"DDI request failed: {request}"
+                    )
+
+                    stats["failed"] += 1
+
+                    status_counter["EXCEPTION"] = (
+                        status_counter.get("EXCEPTION", 0) + 1
+                    )
+
+                    failures.append({
+                        "drug_id": None,
+                        "status_code": None,
+                        "retries": None,
+                        "error": repr(request),
+                    })
+
+                    continue
+
+                print(
+                    f"{request.identifier:8} | "
+                    f"status={request.status_code} | "
+                    f"success={request.success} | "
+                    f"retries={request.retries}"
+                )
+
+                status_label = (
+                    str(request.status_code)
+                    if request.status_code is not None
+                    else "NO_STATUS"
+                )
+
+                status_counter[status_label] = (
+                    status_counter.get(status_label, 0) + 1
+                )
+
+                if request.success:
+                    if request.retries == 1:
+                        stats["success_first_try"] += 1
+                    else:
+                        stats["success_after_retry"] += 1
+
+                    if request.data:
+                        result.extend(request.data)
+
+                    continue
+
+
+                if request.status_code == 404:
+                    stats["not_found"] += 1
+                    continue
+
+                stats["failed"] += 1
+
+                failures.append({
+                    "drug_id": request.identifier,
+                    "status_code": request.status_code,
+                    "retries": request.retries,
+                    "error": request.error,
+                })
+
+            processed = min(
+                batch_start + len(batch),
+                len(drugIds),
+            )
+
+            print(
+                f"Processed {processed}/{len(drugIds)} drugs "
+                f"({processed / len(drugIds) * 100:.1f}%)"
+            )
+
+    with open(
+        "ddi_failures.json",
+        "w",
+        encoding="utf-8",
+    ) as file:
+        json.dump(
+            failures,
+            file,
+            indent=2,
+            ensure_ascii=False,
+        )
+
+    print("\n========== DDI DOWNLOAD SUMMARY ==========")
+
+    print(
+        f"Succeeded on first try : "
+        f"{stats['success_first_try']}"
+    )
+
+    print(
+        f"Succeeded after retry  : "
+        f"{stats['success_after_retry']}"
+    )
+
+    print(
+        f"No DDI record (404)     : "
+        f"{stats['not_found']}"
+    )
+
+    print(
+        f"Failed permanently     : "
+        f"{stats['failed']}"
+    )
+
+    print(
+        "Failure log            : "
+        "ddi_failures.json"
+    )
+
+    print("\nStatus code summary")
+
+    for status, count in sorted(status_counter.items()):
+        print(f"{status}: {count}")
+
+    print(
+        f"\nReturned interaction rows: "
+        f"{len(result)}"
+    )
+
+    return result
 
 def _kegg_from_source_to_target(source_db, target_db, org=None) -> tuple:
 
@@ -690,9 +1014,20 @@ class _Organism(_KeggDatabase):
 
 
     def download_data(self):
-        entries = _kegg_list('organism')
-        self._data = {self.handle(org) : [org_id, org_name] for (org_id, org, org_name, _) in entries}
+        entries = _kegg_list("genome")
 
+        data = {}
+
+        for genome_id, description in entries:
+            # description = "hsa; Homo sapiens (human)"
+            org, org_name = description.split(";", 1)
+
+            data[self.handle(org.strip())] = [
+                genome_id,
+                org_name.strip(),
+            ]
+
+        self._data = data
 
     def handle(self, org):
         return org
@@ -782,23 +1117,15 @@ class _Compound(_SplitDatabase):
 
 class _ConversionTable:
 
-    _table = dict()
-
     def __init__(self):
-        self.download_table()
-
+        self._table = {}
 
     @abstractmethod
     def download_table(self):
         pass
 
-
     def get(self, index):
-        try:
-            return self._table[index]
-        except KeyError:
-            return None
-
+        return self._table.get(index)
 
     def get_table(self):
         return self._table
@@ -807,7 +1134,9 @@ class _ConversionTable:
 class _OrgTable(_ConversionTable):
 
     def __init__(self, org=None):
-        if org != None:
+        super().__init__()
+
+        if org is not None:
             self.download_table(org)
 
 
@@ -851,3 +1180,13 @@ class _ChebiToKegg(_ConversionTable):
     def download_table(self):
         table = _kegg_conv('chebi', 'drug', source_split=True, target_split=True)
         self._table = table
+
+@dataclass
+class RequestResult:
+    identifier: str
+    endpoint: str
+    success: bool
+    retries: int
+    status_code: Optional[int]
+    error: Optional[str]
+    data: list

--- a/config/schema_config.yaml
+++ b/config/schema_config.yaml
@@ -177,6 +177,15 @@ ec number:
     name: str
     rxnfp_embedding: float[]
 
+external ontology term:
+  is_a: named thing
+  represented_as: node
+  preferred_id: id
+  label_in_input: external ontology term
+  properties:
+    name: str
+    ontology: str
+
 # Cell: # relevant?
   # represented_as: node
   # preferred_id: CL
@@ -219,6 +228,18 @@ protein to organism taxon association:
   target: organismTaxon
   label_in_input: Protein_belongs_to_organism
   
+disease to external ontology term mondo association:
+  is_a: association
+  represented_as: edge
+  label_as_edge: disease_has_mondo_relation_to_external_ontology_term
+  source: disease
+  target: external ontology term
+  label_in_input: disease_has_mondo_relation_to_external_ontology_term
+  properties:
+    source: str
+    mondo_relation: str
+    target_ontology: str
+
 post translational interaction:
   is_a: pairwise molecular interaction
   represented_as: edge
@@ -474,6 +495,69 @@ gene to disease association:
     variation_id: str
     pubmed_ids: str[]
     dbsnp_id: str[]
+disease to phenotype mondo association:
+  is_a: association
+  represented_as: edge
+  label_as_edge: disease_has_mondo_relation_to_phenotype
+  source: disease
+  target: phenotype
+  label_in_input: disease_has_mondo_relation_to_phenotype
+  properties:
+    source: str
+    mondo_relation: str
+    target_ontology: str
+
+
+disease to organism taxon mondo association:
+  is_a: association
+  represented_as: edge
+  label_as_edge: disease_has_mondo_relation_to_organism
+  source: disease
+  target: organism taxon
+  label_in_input: disease_has_mondo_relation_to_organism
+  properties:
+    source: str
+    mondo_relation: str
+    target_ontology: str
+
+
+disease to biological process mondo association:
+  is_a: association
+  represented_as: edge
+  label_as_edge: disease_has_mondo_relation_to_biological_process
+  source: disease
+  target: biological process
+  label_in_input: disease_has_mondo_relation_to_biological_process
+  properties:
+    source: str
+    mondo_relation: str
+    target_ontology: str
+
+
+disease to cellular component mondo association:
+  is_a: association
+  represented_as: edge
+  label_as_edge: disease_has_mondo_relation_to_cellular_component
+  source: disease
+  target: cellular component
+  label_in_input: disease_has_mondo_relation_to_cellular_component
+  properties:
+    source: str
+    mondo_relation: str
+    target_ontology: str
+
+
+disease to molecular function mondo association:
+  is_a: association
+  represented_as: edge
+  label_as_edge: disease_has_mondo_relation_to_molecular_function
+  source: disease
+  target: molecular function
+  label_in_input: disease_has_mondo_relation_to_molecular_function
+  properties:
+    source: str
+    mondo_relation: str
+    target_ontology: str
 
 protein to phenotype association:
   is_a: GeneToPhenotypicFeatureAssociation


### PR DESCRIPTION
Kegg:
- Extended KEGG relation support for gene-pathway, gene-drug,
  gene-disease, pathway-drug, pathway-disease, disease-drug,
  and drug-drug associations.

- Added KEGG disease retrieval and identifier conversion utilities
  for NCBI Gene, UniProt, and ChEBI mappings.

- Fixed organism retrieval by using the KEGG genome endpoint and
  correctly parsing organism codes.

- Refactored conversion table state to avoid shared mutable class
  state between instances.

- Implemented asynchronous drug-drug interaction retrieval using
  aiohttp with configurable batching and concurrency.

- Added rate limiting and retry handling for KEGG API responses,
  including Retry-After support, exponential backoff, timeouts,
  client errors, and explicit 404 handling.

- Added structured request result tracking for HTTP status,
  retries, errors, and returned data.

- Validated the full DDI pipeline on 12,879 KEGG drugs:
  6,156 successful responses, 6,723 expected 404/no-record
  responses, 0 permanent failures, and 904,008 interaction rows.
  
  MONDO hierarchy and cross-ontology relations
  
  - Extended the Disease adapter with MONDO cross-ontology relation
  support while preserving MONDO-to-MONDO hierarchical relations.

- Parsed both direct OBO is_a relationships and explicit
  relationship fields from the MONDO ontology.

- Filtered malformed, metadata-only, internal MONDO, and duplicate
  cross-ontology records while preserving the original MONDO
  predicate as an edge property.

- Added dedicated MONDO edges to existing CROssBAR node types:
  phenotype (HP), organism taxon (NCBITaxon), and Gene Ontology
  biological process, cellular component, and molecular function
  nodes.

- Added GO aspect-based typing to map MONDO-GO relations to the
  appropriate CROssBAR GO node class.

- Added generic external ontology term nodes for MONDO targets
  without dedicated CROssBAR adapters, including their ontology
  source and term names.

- Added target ontology and relation-type filtering for MONDO
  cross-ontology relations.

- Integrated MONDO cross-ontology nodes and edges into the main
  get_nodes() and get_edges() pipelines.

- Added separate CSV export for disease and external ontology term
  nodes to prevent external terms from being written as diseases.

- Improved CURIE prefix handling to avoid duplicate prefixes for
  already-prefixed identifiers.

- Added BioCypher schema definitions for the new MONDO relation
  types and the external ontology term node class.

- Restored and verified existing Disease adapter helper and edge
  generation methods after integration.

- Validated the final implementation with 46,447 MONDO hierarchy
  edges, 6,318 cross-ontology edges, 1,111 external ontology nodes,
  zero duplicate edges, and zero missing generic target nodes.

- Verified CSV separation, schema compatibility, and successful
  BioCypher node/edge writing with an end-to-end integration test.